### PR TITLE
fix: echo Gemini thought_signature in function call history

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1087,16 +1087,19 @@ mod tests {
                 id: "1".into(),
                 function_name: "Read".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
             ToolCall {
                 id: "2".into(),
                 function_name: "Grep".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
             ToolCall {
                 id: "3".into(),
                 function_name: "List".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
         ];
         assert!(can_parallelize(&calls, ApprovalMode::Normal, &[]));
@@ -1109,11 +1112,13 @@ mod tests {
                 id: "1".into(),
                 function_name: "Read".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
             ToolCall {
                 id: "2".into(),
                 function_name: "Write".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
         ];
         assert!(!can_parallelize(&calls, ApprovalMode::Normal, &[]));
@@ -1126,11 +1131,13 @@ mod tests {
                 id: "1".into(),
                 function_name: "Read".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
             ToolCall {
                 id: "2".into(),
                 function_name: "Bash".into(),
                 arguments: r#"{"command": "./deploy.sh"}"#.into(),
+                thought_signature: None,
             },
         ];
         assert!(!can_parallelize(&calls, ApprovalMode::Normal, &[]));
@@ -1143,11 +1150,13 @@ mod tests {
                 id: "1".into(),
                 function_name: "Read".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
             ToolCall {
                 id: "2".into(),
                 function_name: "Bash".into(),
                 arguments: r#"{"command": "cargo test"}"#.into(),
+                thought_signature: None,
             },
         ];
         assert!(can_parallelize(&calls, ApprovalMode::Normal, &[]));
@@ -1160,11 +1169,13 @@ mod tests {
                 id: "1".into(),
                 function_name: "Write".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
             ToolCall {
                 id: "2".into(),
                 function_name: "Delete".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
         ];
         assert!(can_parallelize(&calls, ApprovalMode::Yolo, &[]));
@@ -1177,11 +1188,13 @@ mod tests {
                 id: "1".into(),
                 function_name: "InvokeAgent".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
             ToolCall {
                 id: "2".into(),
                 function_name: "InvokeAgent".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             },
         ];
         // InvokeAgent auto-approves in all modes (sub-agents inherit

--- a/src/loop_guard.rs
+++ b/src/loop_guard.rs
@@ -140,6 +140,7 @@ mod tests {
             id: "x".into(),
             function_name: name.into(),
             arguments: args.into(),
+            thought_signature: None,
         }
     }
 

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -269,6 +269,7 @@ impl LlmProvider for AnthropicProvider {
                         id,
                         function_name: name,
                         arguments: serde_json::to_string(&input)?,
+                        thought_signature: None,
                     });
                 }
                 _ => {}
@@ -521,6 +522,7 @@ impl LlmProvider for AnthropicProvider {
                         id,
                         function_name: name,
                         arguments: args,
+                        thought_signature: None,
                     })
                     .collect();
                 let _ = tx.send(StreamChunk::ToolCalls(tcs)).await;
@@ -684,6 +686,7 @@ mod tests {
                 id: "tc_1".into(),
                 function_name: "Read".into(),
                 arguments: r#"{"path":"main.rs"}"#.into(),
+                thought_signature: None,
             }]),
             tool_call_id: None,
             images: None,
@@ -740,6 +743,7 @@ mod tests {
                 id: "tc_2".into(),
                 function_name: "Bash".into(),
                 arguments: r#"{"command":"cargo test"}"#.into(),
+                thought_signature: None,
             }]),
             tool_call_id: None,
             images: None,

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -109,6 +109,9 @@ struct ResponsePart {
     text: Option<String>,
     #[serde(default)]
     function_call: Option<FunctionCallResponse>,
+    /// Thought signature that must be echoed back when replaying this part.
+    #[serde(default)]
+    thought_signature: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -336,6 +339,7 @@ impl LlmProvider for GeminiProvider {
                                             function_name: fc.name.clone(),
                                             arguments: serde_json::to_string(&fc.args)
                                                 .unwrap_or_default(),
+                                            thought_signature: part.thought_signature.clone(),
                                         });
                                     }
                                 }
@@ -409,13 +413,16 @@ impl GeminiProvider {
                 for tc in tcs {
                     let args: serde_json::Value =
                         serde_json::from_str(&tc.arguments).unwrap_or_default();
-                    parts.push(
-                        Part::FunctionCall {
-                            name: tc.function_name.clone(),
-                            args,
-                        }
-                        .to_json(),
-                    );
+                    let mut fc_part = Part::FunctionCall {
+                        name: tc.function_name.clone(),
+                        args,
+                    }
+                    .to_json();
+                    // Echo back thought_signature if present (required by Gemini API)
+                    if let Some(ref sig) = tc.thought_signature {
+                        fc_part["thoughtSignature"] = serde_json::json!(sig);
+                    }
+                    parts.push(fc_part);
                 }
                 contents.push(serde_json::json!({ "role": "model", "parts": parts }));
                 continue;
@@ -517,6 +524,7 @@ impl GeminiProvider {
                                 id: format!("gemini_tc_{tc_counter}"),
                                 function_name: fc.name,
                                 arguments: serde_json::to_string(&fc.args)?,
+                                thought_signature: part.thought_signature,
                             });
                         }
                     }
@@ -612,6 +620,7 @@ mod tests {
                 id: "tc_1".into(),
                 function_name: "Read".into(),
                 arguments: r#"{"path":"main.rs"}"#.into(),
+                thought_signature: None,
             }]),
             tool_call_id: None,
             images: None,
@@ -678,6 +687,7 @@ mod tests {
                     parts: Some(vec![ResponsePart {
                         text: Some("Hello!".into()),
                         function_call: None,
+                        thought_signature: None,
                     }]),
                 }),
             }]),
@@ -706,6 +716,7 @@ mod tests {
                             name: "Read".into(),
                             args: serde_json::json!({"path": "main.rs"}),
                         }),
+                        thought_signature: None,
                     }]),
                 }),
             }]),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -16,6 +16,9 @@ pub struct ToolCall {
     pub id: String,
     pub function_name: String,
     pub arguments: String, // Raw JSON string
+    /// Gemini-specific: thought signature that must be echoed back in history.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub thought_signature: Option<String>,
 }
 
 /// Token usage from an LLM response.

--- a/src/providers/openai_compat.rs
+++ b/src/providers/openai_compat.rs
@@ -301,6 +301,7 @@ impl LlmProvider for OpenAiCompatProvider {
                 id: tc.id,
                 function_name: tc.function.name,
                 arguments: tc.function.arguments,
+                thought_signature: None,
             })
             .collect();
 
@@ -374,6 +375,7 @@ impl LlmProvider for OpenAiCompatProvider {
                                     id,
                                     function_name: name,
                                     arguments: args,
+                                    thought_signature: None,
                                 })
                                 .collect();
                             let _ = tx.send(StreamChunk::ToolCalls(tcs)).await;
@@ -443,6 +445,7 @@ impl LlmProvider for OpenAiCompatProvider {
                         id,
                         function_name: name,
                         arguments: args,
+                        thought_signature: None,
                     })
                     .collect();
                 let _ = tx.send(StreamChunk::ToolCalls(tcs)).await;
@@ -599,6 +602,7 @@ mod tests {
                 id: "tc_1".into(),
                 function_name: "Read".into(),
                 arguments: r#"{"path":"main.rs"}"#.into(),
+                thought_signature: None,
             }]),
             tool_call_id: None,
             images: None,


### PR DESCRIPTION
## Summary

Fixes #9 — Gemini API returns 400 Bad Request when tool calls are replayed without `thought_signature`.

## Root Cause

Gemini's API now requires a `thought_signature` field in `functionCall` parts when replaying conversation history. Koda wasn't capturing it from responses or echoing it back, causing:

```
Gemini API returned 400 Bad Request: Function call is missing a thought_signature
in functionCall parts. This is required for tools to work correctly...
```

## Changes

1. **Capture:** Added `thought_signature: Option<String>` to `ToolCall` struct. Gemini's `ResponsePart` now deserializes the field from both streaming and non-streaming responses.

2. **Store:** The field persists through existing `tool_calls` JSON serialization in the DB. No schema change needed — `serde` handles the optional field gracefully (old records without it deserialize as `None`).

3. **Echo:** `convert_messages()` includes `thoughtSignature` in function call parts when building history for the next API call. Only included when present (Gemini-only).

## Backward Compatibility

- Other providers (OpenAI, Anthropic) set `thought_signature: None`, which is skipped in serialization
- Old DB records without the field deserialize correctly via `#[serde(default)]`
- No impact on non-Gemini providers

## Testing

All 323 tests pass. Affected files:
- `src/providers/mod.rs` — ToolCall struct
- `src/providers/gemini.rs` — capture + echo
- `src/providers/anthropic.rs` — None for new field
- `src/providers/openai_compat.rs` — None for new field
- `src/loop_guard.rs` — test helper
- `src/inference.rs` — test helpers