### PR TITLE
feat: Add support for more OpenAI-compatible providers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -36,34 +36,32 @@ pub async fn run(
     let provider: Arc<RwLock<Box<dyn LlmProvider>>> =
         Arc::new(RwLock::new(create_provider(&config)));
 
-    // Auto-detect the serving model for LM Studio
-    if config.provider_type == ProviderType::LMStudio {
+    // Auto-detect the serving model for local providers
+    if config.model == "auto-detect" {
         let prov = provider.read().await;
         match prov.list_models().await {
             Ok(models) if !models.is_empty() => {
                 config.model = models[0].id.clone();
                 config.model_settings.model = config.model.clone();
-                tracing::info!("Auto-detected LM Studio model: {}", config.model);
+                tracing::info!("Auto-detected model: {}", config.model);
             }
             Ok(_) => {
                 config.model = "(no model loaded)".to_string();
                 config.model_settings.model = config.model.clone();
-                eprintln!("  \x1b[33m\u{26a0} No model loaded in LM Studio.\x1b[0m");
                 eprintln!(
-                    "    Load a model in LM Studio, then use \x1b[36m/model\x1b[0m to select it."
+                    "  \x1b[33m\u{26a0} No model loaded in {}.\x1b[0m",
+                    config.provider_type
                 );
+                eprintln!("    Load a model, then use \x1b[36m/model\x1b[0m to select it.");
             }
             Err(e) => {
                 config.model = "(connection failed)".to_string();
                 config.model_settings.model = config.model.clone();
                 eprintln!(
-                    "  \x1b[31m\u{2717} Could not connect to LM Studio at {}\x1b[0m",
-                    config.base_url
+                    "  \x1b[31m\u{2717} Could not connect to {} at {}\x1b[0m",
+                    config.provider_type, config.base_url
                 );
-                eprintln!("    {e}");
-                eprintln!(
-                    "    Make sure LM Studio is running, or switch provider with \x1b[36m/provider\x1b[0m"
-                );
+                tracing::warn!("Auto-detect failed: {e}");
             }
         }
     }
@@ -891,7 +889,7 @@ async fn handle_setup_provider(
     base_url: String,
 ) {
     let env_name = ptype.env_key_name();
-    let key_missing = ptype != ProviderType::LMStudio && !crate::runtime_env::is_set(env_name);
+    let key_missing = ptype.requires_api_key() && !crate::runtime_env::is_set(env_name);
     let is_same_provider = ptype == config.provider_type;
 
     config.provider_type = ptype.clone();
@@ -899,7 +897,7 @@ async fn handle_setup_provider(
     config.model = ptype.default_model().to_string();
     config.model_settings.model = config.model.clone();
 
-    if key_missing || (is_same_provider && ptype != ProviderType::LMStudio) {
+    if key_missing || (is_same_provider && ptype.requires_api_key()) {
         let prompt_msg = if is_same_provider {
             format!(
                 "  Update {} API key (enter to keep current): ",

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,9 +14,22 @@ pub enum ProviderType {
     Gemini,
     Groq,
     Grok,
+    Ollama,
+    DeepSeek,
+    Mistral,
+    MiniMax,
+    OpenRouter,
+    Together,
+    Fireworks,
+    Vllm,
 }
 
 impl ProviderType {
+    /// Returns true if this provider requires an API key to function.
+    pub fn requires_api_key(&self) -> bool {
+        !matches!(self, Self::LMStudio | Self::Ollama | Self::Vllm)
+    }
+
     /// Detect provider type from a base URL or explicit name.
     pub fn from_url_or_name(url: &str, name: Option<&str>) -> Self {
         if let Some(n) = name {
@@ -26,12 +39,25 @@ impl ProviderType {
                 "groq" => Self::Groq,
                 "grok" | "xai" => Self::Grok,
                 "lmstudio" | "lm-studio" => Self::LMStudio,
+                "ollama" => Self::Ollama,
+                "deepseek" => Self::DeepSeek,
+                "mistral" => Self::Mistral,
+                "minimax" => Self::MiniMax,
+                "openrouter" => Self::OpenRouter,
+                "together" => Self::Together,
+                "fireworks" => Self::Fireworks,
+                "vllm" => Self::Vllm,
                 _ => Self::OpenAI,
             };
         }
         // Auto-detect from URL
+        let url = url.to_lowercase();
         if url.contains("anthropic.com") {
             Self::Anthropic
+        } else if url.contains("localhost:11434") || url.contains("127.0.0.1:11434") {
+            Self::Ollama
+        } else if url.contains("localhost:8000") || url.contains("127.0.0.1:8000") {
+            Self::Vllm
         } else if url.contains("localhost") || url.contains("127.0.0.1") {
             Self::LMStudio
         } else if url.contains("generativelanguage.googleapis.com") {
@@ -40,6 +66,18 @@ impl ProviderType {
             Self::Groq
         } else if url.contains("x.ai") {
             Self::Grok
+        } else if url.contains("deepseek.com") {
+            Self::DeepSeek
+        } else if url.contains("mistral.ai") {
+            Self::Mistral
+        } else if url.contains("minimax.chat") || url.contains("minimaxi.com") {
+            Self::MiniMax
+        } else if url.contains("openrouter.ai") {
+            Self::OpenRouter
+        } else if url.contains("together.xyz") {
+            Self::Together
+        } else if url.contains("fireworks.ai") {
+            Self::Fireworks
         } else {
             Self::OpenAI
         }
@@ -53,6 +91,14 @@ impl ProviderType {
             Self::Gemini => "https://generativelanguage.googleapis.com",
             Self::Groq => "https://api.groq.com/openai/v1",
             Self::Grok => "https://api.x.ai/v1",
+            Self::Ollama => "http://localhost:11434/v1",
+            Self::DeepSeek => "https://api.deepseek.com/v1",
+            Self::Mistral => "https://api.mistral.ai/v1",
+            Self::MiniMax => "https://api.minimax.chat/v1",
+            Self::OpenRouter => "https://openrouter.ai/api/v1",
+            Self::Together => "https://api.together.xyz/v1",
+            Self::Fireworks => "https://api.fireworks.ai/inference/v1",
+            Self::Vllm => "http://localhost:8000/v1",
         }
     }
 
@@ -64,6 +110,14 @@ impl ProviderType {
             Self::Gemini => "gemini-2.0-flash",
             Self::Groq => "llama-3.3-70b-versatile",
             Self::Grok => "grok-3",
+            Self::Ollama => "auto-detect",
+            Self::DeepSeek => "deepseek-chat",
+            Self::Mistral => "mistral-large-latest",
+            Self::MiniMax => "minimax-text-01",
+            Self::OpenRouter => "anthropic/claude-3.5-sonnet",
+            Self::Together => "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            Self::Fireworks => "accounts/fireworks/models/llama-v3p3-70b-instruct",
+            Self::Vllm => "auto-detect",
         }
     }
 
@@ -75,6 +129,14 @@ impl ProviderType {
             Self::Gemini => "GEMINI_API_KEY",
             Self::Groq => "GROQ_API_KEY",
             Self::Grok => "XAI_API_KEY",
+            Self::Ollama => "KODA_API_KEY",
+            Self::DeepSeek => "DEEPSEEK_API_KEY",
+            Self::Mistral => "MISTRAL_API_KEY",
+            Self::MiniMax => "MINIMAX_API_KEY",
+            Self::OpenRouter => "OPENROUTER_API_KEY",
+            Self::Together => "TOGETHER_API_KEY",
+            Self::Fireworks => "FIREWORKS_API_KEY",
+            Self::Vllm => "KODA_API_KEY",
         }
     }
 }
@@ -88,6 +150,14 @@ impl std::fmt::Display for ProviderType {
             Self::Gemini => write!(f, "gemini"),
             Self::Groq => write!(f, "groq"),
             Self::Grok => write!(f, "grok"),
+            Self::Ollama => write!(f, "ollama"),
+            Self::DeepSeek => write!(f, "deepseek"),
+            Self::Mistral => write!(f, "mistral"),
+            Self::MiniMax => write!(f, "minimax"),
+            Self::OpenRouter => write!(f, "openrouter"),
+            Self::Together => write!(f, "together"),
+            Self::Fireworks => write!(f, "fireworks"),
+            Self::Vllm => write!(f, "vllm"),
         }
     }
 }

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -33,11 +33,25 @@ pub fn run_wizard() -> Option<ProviderType> {
             "LM Studio",
             "Local models, no API key needed (localhost:1234)",
         ),
+        SelectOption::new(
+            "Ollama",
+            "Local models, no API key needed (localhost:11434)",
+        ),
         SelectOption::new("OpenAI", "GPT-4o, o1, o3 (requires API key)"),
         SelectOption::new("Anthropic", "Claude Sonnet, Opus (requires API key)"),
+        SelectOption::new("DeepSeek", "DeepSeek-V3, R1 (requires API key)"),
         SelectOption::new("Gemini", "Google Gemini (requires API key)"),
         SelectOption::new("Groq", "Fast inference (requires API key)"),
         SelectOption::new("Grok", "xAI Grok (requires API key)"),
+        SelectOption::new("Mistral", "Mistral Large, Codestral (requires API key)"),
+        SelectOption::new("MiniMax", "MiniMax-01 (requires API key)"),
+        SelectOption::new(
+            "OpenRouter",
+            "Meta-provider, 100+ models (requires API key)",
+        ),
+        SelectOption::new("Together", "Open-source model hosting (requires API key)"),
+        SelectOption::new("Fireworks", "Fast inference (requires API key)"),
+        SelectOption::new("vLLM", "Local high-performance serving (localhost:8000)"),
     ];
 
     let selection = match crate::tui::select("\u{1f43b} Choose your LLM provider", &options, 0) {
@@ -52,17 +66,25 @@ pub fn run_wizard() -> Option<ProviderType> {
 
     let provider_type = match selection {
         0 => ProviderType::LMStudio,
-        1 => ProviderType::OpenAI,
-        2 => ProviderType::Anthropic,
-        3 => ProviderType::Gemini,
-        4 => ProviderType::Groq,
-        5 => ProviderType::Grok,
+        1 => ProviderType::Ollama,
+        2 => ProviderType::OpenAI,
+        3 => ProviderType::Anthropic,
+        4 => ProviderType::DeepSeek,
+        5 => ProviderType::Gemini,
+        6 => ProviderType::Groq,
+        7 => ProviderType::Grok,
+        8 => ProviderType::Mistral,
+        9 => ProviderType::MiniMax,
+        10 => ProviderType::OpenRouter,
+        11 => ProviderType::Together,
+        12 => ProviderType::Fireworks,
+        13 => ProviderType::Vllm,
         _ => ProviderType::LMStudio,
     };
 
     // Step 2: API key (if needed)
     let env_key = provider_type.env_key_name();
-    if env_key != "KODA_API_KEY" {
+    if provider_type.requires_api_key() {
         // Cloud provider — needs an API key
         if crate::runtime_env::is_set(env_key) {
             println!();
@@ -104,8 +126,14 @@ pub fn run_wizard() -> Option<ProviderType> {
         }
     } else {
         println!();
-        println!("  \x1b[32m\u{2713}\x1b[0m LM Studio selected \u{2014} no API key needed");
-        println!("  \x1b[90mMake sure LM Studio is running on localhost:1234\x1b[0m");
+        println!(
+            "  \x1b[32m\u{2713}\x1b[0m {} selected \u{2014} no API key needed",
+            provider_type
+        );
+        println!(
+            "  \x1b[90mMake sure it is running at {}\x1b[0m",
+            provider_type.default_base_url()
+        );
     }
 
     println!();

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -231,11 +231,19 @@ pub async fn handle_command(
 /// Available providers for the interactive picker.
 pub const PROVIDERS: &[(&str, &str, &str)] = &[
     ("lmstudio", "LM Studio", "Local models, no API key needed"),
-    ("openai", "OpenAI", "GPT-4o, GPT-4, GPT-3.5"),
-    ("anthropic", "Anthropic", "Claude Sonnet, Haiku, Opus"),
+    ("ollama", "Ollama", "Local models, no API key needed"),
+    ("openai", "OpenAI", "GPT-4o, o1, o3"),
+    ("anthropic", "Anthropic", "Claude Sonnet, Opus"),
+    ("deepseek", "DeepSeek", "DeepSeek-V3, R1"),
     ("gemini", "Google Gemini", "Gemini 2.0 Flash, Pro"),
-    ("groq", "Groq", "Llama 3.3, Mixtral (fast)"),
+    ("groq", "Groq", "Fast inference"),
     ("grok", "Grok (xAI)", "Grok-3, Grok-2"),
+    ("mistral", "Mistral", "Mistral Large, Codestral"),
+    ("minimax", "MiniMax", "MiniMax-01"),
+    ("openrouter", "OpenRouter", "Meta-provider, 100+ models"),
+    ("together", "Together", "Open-source model hosting"),
+    ("fireworks", "Fireworks", "Fast inference"),
+    ("vllm", "vLLM", "Local high-performance serving"),
 ];
 
 // \u{2500}\u{2500} Display Helpers \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}


### PR DESCRIPTION
Closes #13

Adds native `/provider` menu support for the following OpenAI-compatible providers via our existing robust implementation:
- Ollama
- DeepSeek
- Mistral
- MiniMax
- OpenRouter
- Together
- Fireworks
- vLLM

**Key Improvements:**
- Added robust API key detection (local providers like Ollama/vLLM don't prompt for API keys during setup).
- Expanded auto-detect functionality for models so Ollama and vLLM will automatically query their `/v1/models` endpoint for the first available model, just like LM Studio.
- Updated onboarding and REPL menus.