### PR TITLE
feat: prompt for custom URL for local providers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -936,7 +936,28 @@ async fn handle_setup_provider(
                 }
             }
             Err(_) => {
-                println!("  \x1b[31mCancelled, provider not changed.\x1b[0m");
+                println!("  \x1b[31mProvider switch cancelled.\x1b[0m");
+                return;
+            }
+        }
+    } else if !ptype.requires_api_key() {
+        let default_url = ptype.default_base_url();
+        let prompt_msg = format!("  Enter {} URL (enter for {}): ", ptype, default_url);
+        match rl.readline(&prompt_msg) {
+            Ok(url) => {
+                let url = url.trim();
+                if !url.is_empty() {
+                    config.base_url = url.to_string();
+                } else {
+                    config.base_url = default_url.to_string();
+                }
+                println!(
+                    "  \x1b[32m\u{2713}\x1b[0m URL set to \x1b[36m{}\x1b[0m",
+                    config.base_url
+                );
+            }
+            Err(_) => {
+                println!("  \x1b[31mProvider switch cancelled.\x1b[0m");
                 return;
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -269,9 +269,16 @@ impl KodaConfig {
             .clone()
             .unwrap_or_else(|| "http://localhost:1234/v1".to_string());
         let provider_type = ProviderType::from_url_or_name(&default_url, agent.provider.as_deref());
-        let base_url = agent
-            .base_url
-            .unwrap_or_else(|| provider_type.default_base_url().to_string());
+
+        // If it's a local provider and we have a user-defined default in env, use it
+        let mut base_url = agent.base_url;
+        if base_url.is_none() && !provider_type.requires_api_key() {
+            if let Some(env_url) = crate::runtime_env::get("KODA_LOCAL_URL") {
+                base_url = Some(env_url);
+            }
+        }
+
+        let base_url = base_url.unwrap_or_else(|| provider_type.default_base_url().to_string());
         let model = agent
             .model
             .unwrap_or_else(|| provider_type.default_model().to_string());

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,10 +272,11 @@ impl KodaConfig {
 
         // If it's a local provider and we have a user-defined default in env, use it
         let mut base_url = agent.base_url;
-        if base_url.is_none() && !provider_type.requires_api_key() {
-            if let Some(env_url) = crate::runtime_env::get("KODA_LOCAL_URL") {
-                base_url = Some(env_url);
-            }
+        if base_url.is_none()
+            && !provider_type.requires_api_key()
+            && let Some(env_url) = crate::runtime_env::get("KODA_LOCAL_URL")
+        {
+            base_url = Some(env_url);
         }
 
         let base_url = base_url.unwrap_or_else(|| provider_type.default_base_url().to_string());

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -130,10 +130,32 @@ pub fn run_wizard() -> Option<ProviderType> {
             "  \x1b[32m\u{2713}\x1b[0m {} selected \u{2014} no API key needed",
             provider_type
         );
+        let default_url = provider_type.default_base_url();
         println!(
-            "  \x1b[90mMake sure it is running at {}\x1b[0m",
-            provider_type.default_base_url()
+            "  \x1b[90mEnter URL (or press Enter for {}):\x1b[0m",
+            default_url
         );
+        print!("  \x1b[32m\u{276f}\x1b[0m ");
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+
+        let mut url = String::new();
+        if std::io::stdin().read_line(&mut url).is_ok() {
+            let url = url.trim();
+            if !url.is_empty() {
+                // If the user typed a URL, we need to update the env or config
+                // Since this is onboarding, we just print instructions on how to use it
+                // because the onboarding wizard currently only returns the ProviderType
+                // To actually set the URL, Koda reads `--base-url` or uses defaults.
+                // We'll update the process env so `config.rs` picks it up if we added support for it.
+                // For now, we just acknowledge it.
+                println!("  \x1b[32m\u{2713}\x1b[0m Will connect to {}", url);
+                // Note: to fully support this in onboarding without changing its return signature,
+                // we can export it to the environment as a fallback.
+                crate::runtime_env::set("KODA_LOCAL_URL", url);
+            } else {
+                println!("  \x1b[90mUsing default: {}\x1b[0m", default_url);
+            }
+        }
     }
 
     println!();


### PR DESCRIPTION
Closes #14

Adds interactive prompts for custom URLs when configuring local providers.