### PR TITLE
feat: route approval flow through EngineSink

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -461,7 +461,7 @@ pub async fn run(
             pending_images,
             current_mode,
             &mut settings,
-            &crate::engine::CliSink,
+            &crate::engine::CliSink::new(),
         )
         .await?;
 
@@ -571,7 +571,7 @@ pub async fn run_headless(
         pending_images,
         ApprovalMode::Yolo,
         &mut settings,
-        &crate::engine::CliSink,
+        &crate::engine::CliSink::new(),
     )
     .await;
 

--- a/src/engine/sink.rs
+++ b/src/engine/sink.rs
@@ -36,11 +36,15 @@ pub trait EngineSink: Send + Sync {
 /// This reproduces the exact current terminal output by delegating
 /// to `display::` and `println!()`. It's the default sink used in
 /// interactive and headless modes.
-pub struct CliSink;
+pub struct CliSink {
+    md: std::sync::Mutex<crate::markdown::MarkdownStreamer>,
+}
 
 impl CliSink {
     pub fn new() -> Self {
-        Self
+        Self {
+            md: std::sync::Mutex::new(crate::markdown::MarkdownStreamer::new()),
+        }
     }
 }
 
@@ -53,9 +57,11 @@ impl Default for CliSink {
 impl EngineSink for CliSink {
     fn emit(&self, event: EngineEvent) {
         match event {
-            EngineEvent::TextDelta { .. } | EngineEvent::TextDone => {
-                // Streaming text is handled by MarkdownStreamer in inference.rs,
-                // not through the sink (yet). These events are for future clients.
+            EngineEvent::TextDelta { text } => {
+                self.md.lock().unwrap().push(&text);
+            }
+            EngineEvent::TextDone => {
+                self.md.lock().unwrap().flush();
             }
             EngineEvent::ThinkingStart => {
                 crate::display::print_thinking_banner();

--- a/src/engine/sink.rs
+++ b/src/engine/sink.rs
@@ -5,7 +5,7 @@
 //! using the existing display/markdown infrastructure — preserving the exact
 //! current user experience.
 
-use super::event::EngineEvent;
+use super::event::{ApprovalDecision, EngineEvent};
 
 /// Trait for consuming engine events.
 ///
@@ -16,6 +16,19 @@ use super::event::EngineEvent;
 pub trait EngineSink: Send + Sync {
     /// Emit an engine event to the client.
     fn emit(&self, event: EngineEvent);
+
+    /// Request approval from the user for a tool action.
+    ///
+    /// This is a blocking request/response: the engine pauses until the
+    /// client decides. In CLI mode, this shows an interactive select widget.
+    /// In server mode, this sends a WebSocket message and awaits the response.
+    fn request_approval(
+        &self,
+        tool_name: &str,
+        detail: &str,
+        preview: Option<&str>,
+        whitelist_hint: Option<&str>,
+    ) -> ApprovalDecision;
 }
 
 /// The CLI sink that renders EngineEvents to the terminal.
@@ -80,8 +93,7 @@ impl EngineSink for CliSink {
             }
             EngineEvent::SubAgentEnd { .. } => {}
             EngineEvent::ApprovalRequest { .. } => {
-                // Approval is handled separately via channels (see #41).
-                // The CLI adapter will intercept this in the REPL loop.
+                // Approval is handled via request_approval(), not emit().
             }
             EngineEvent::ActionBlocked {
                 tool_name: _,
@@ -163,8 +175,25 @@ impl EngineSink for CliSink {
             }
         }
     }
-}
 
+    fn request_approval(
+        &self,
+        tool_name: &str,
+        detail: &str,
+        preview: Option<&str>,
+        whitelist_hint: Option<&str>,
+    ) -> ApprovalDecision {
+        use crate::confirm::{self, Confirmation};
+        match confirm::confirm_tool_action(tool_name, detail, preview, whitelist_hint) {
+            Confirmation::Approved => ApprovalDecision::Approve,
+            Confirmation::Rejected => ApprovalDecision::Reject,
+            Confirmation::RejectedWithFeedback(fb) => {
+                ApprovalDecision::RejectWithFeedback { feedback: fb }
+            }
+            Confirmation::AlwaysAllow => ApprovalDecision::AlwaysAllow,
+        }
+    }
+}
 /// A sink that collects events into a Vec for testing.
 #[derive(Debug, Default)]
 pub struct TestSink {
@@ -195,6 +224,16 @@ impl TestSink {
 impl EngineSink for TestSink {
     fn emit(&self, event: EngineEvent) {
         self.events.lock().unwrap().push(event);
+    }
+
+    fn request_approval(
+        &self,
+        _tool_name: &str,
+        _detail: &str,
+        _preview: Option<&str>,
+        _whitelist_hint: Option<&str>,
+    ) -> ApprovalDecision {
+        ApprovalDecision::Approve
     }
 }
 

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -5,9 +5,9 @@
 
 use crate::approval::{self, ApprovalMode, Settings, ToolApproval};
 use crate::config::KodaConfig;
-use crate::confirm::{self, Confirmation};
+use crate::confirm;
 use crate::db::{Database, Role};
-use crate::engine::EngineEvent;
+use crate::engine::{ApprovalDecision, EngineEvent};
 use crate::interrupt;
 use crate::loop_guard::{self, LoopDetector};
 use crate::memory;
@@ -689,14 +689,14 @@ async fn execute_tools_sequential(
                     None
                 };
 
-                match confirm::confirm_tool_action(
+                match sink.request_approval(
                     &tc.function_name,
                     &detail,
                     diff_preview.as_deref(),
                     whitelist_hint.as_deref(),
                 ) {
-                    Confirmation::Approved => {}
-                    Confirmation::AlwaysAllow => {
+                    ApprovalDecision::Approve => {}
+                    ApprovalDecision::AlwaysAllow => {
                         // Add to whitelist and persist
                         if let Some(ref pattern) = whitelist_hint {
                             if let Err(e) = settings.add_allowed_command(pattern) {
@@ -709,7 +709,7 @@ async fn execute_tools_sequential(
                         }
                         // Fall through to execute
                     }
-                    Confirmation::Rejected => {
+                    ApprovalDecision::Reject => {
                         db.insert_message(
                             session_id,
                             &Role::Tool,
@@ -721,7 +721,7 @@ async fn execute_tools_sequential(
                         .await?;
                         continue;
                     }
-                    Confirmation::RejectedWithFeedback(feedback) => {
+                    ApprovalDecision::RejectWithFeedback { feedback } => {
                         let result = format!("User rejected this action with feedback: {feedback}");
                         db.insert_message(
                             session_id,
@@ -913,24 +913,24 @@ async fn execute_sub_agent(
                     } else {
                         None
                     };
-                    match confirm::confirm_tool_action(
+                    match sink.request_approval(
                         &tc.function_name,
                         &detail,
                         diff_preview.as_deref(),
                         whitelist_hint.as_deref(),
                     ) {
-                        confirm::Confirmation::Approved => {
+                        ApprovalDecision::Approve => {
                             tools.execute(&tc.function_name, &tc.arguments).await.output
                         }
-                        confirm::Confirmation::AlwaysAllow => {
+                        ApprovalDecision::AlwaysAllow => {
                             if let Some(ref pattern) = whitelist_hint {
                                 let _ = settings.add_allowed_command(pattern);
                             }
                             tools.execute(&tc.function_name, &tc.arguments).await.output
                         }
-                        confirm::Confirmation::Rejected => "[rejected by user]".to_string(),
-                        confirm::Confirmation::RejectedWithFeedback(fb) => {
-                            format!("[rejected: {fb}]")
+                        ApprovalDecision::Reject => "[rejected by user]".to_string(),
+                        ApprovalDecision::RejectWithFeedback { feedback } => {
+                            format!("[rejected: {feedback}]")
                         }
                     }
                 }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -135,15 +135,12 @@ pub async fn inference_loop(
             .await
             .context("LLM inference failed")?;
 
-        // Collect the streamed response with markdown rendering
-        let mut md = crate::markdown::MarkdownStreamer::new();
+        // Collect the streamed response
         let mut full_text = String::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
         let mut usage = crate::providers::TokenUsage::default();
         let mut first_token = true;
         let mut char_count: usize = 0;
-        let mut in_think_block = false;
-        let mut think_buffer = String::new();
         let mut native_think_buf = String::new();
         let mut response_banner_shown = false;
         let mut thinking_banner_shown = false;
@@ -167,7 +164,7 @@ pub async fn inference_loop(
             if interrupted || interrupt::is_interrupted() {
                 spinner.finish_and_clear();
                 if !full_text.is_empty() {
-                    md.flush();
+                    sink.emit(EngineEvent::TextDone);
                 }
                 println!("\n\x1b[33m\u{26a0} Interrupted\x1b[0m");
                 interrupt::clear();
@@ -192,7 +189,7 @@ pub async fn inference_loop(
             match chunk {
                 StreamChunk::TextDelta(delta) => {
                     if first_token {
-                        // Flush any buffered native thinking before showing response
+                        // Flush any buffered thinking before showing response
                         if !native_think_buf.is_empty() {
                             spinner.finish_and_clear();
                             sink.emit(EngineEvent::ThinkingStart);
@@ -206,79 +203,34 @@ pub async fn inference_loop(
                         first_token = false;
                     }
 
-                    // If we just finished native thinking, show response banner
+                    // Show response banner if coming from thinking
                     if thinking_banner_shown && !response_banner_shown && !delta.trim().is_empty() {
                         sink.emit(EngineEvent::ResponseStart);
                         response_banner_shown = true;
                     }
 
-                    // Detect <think>...</think> tags for reasoning models
-                    // (DeepSeek-R1, Qwen QwQ, etc.)
+                    // Show response banner on first non-empty text
+                    if !response_banner_shown && !delta.trim().is_empty() {
+                        sink.emit(EngineEvent::ResponseStart);
+                        response_banner_shown = true;
+                    }
+
                     full_text.push_str(&delta);
                     char_count += delta.len();
-                    think_buffer.push_str(&delta);
-
-                    // Process the buffer for think tags
-                    loop {
-                        if in_think_block {
-                            // Looking for </think>
-                            if let Some(end_pos) = think_buffer.find("</think>") {
-                                // Render structured thinking block when complete
-                                let thinking = &think_buffer[..end_pos];
-                                if !thinking.is_empty() {
-                                    sink.emit(EngineEvent::ThinkingDelta {
-                                        text: thinking.to_string(),
-                                    });
-                                }
-                                think_buffer = think_buffer[end_pos + 8..].to_string();
-                                in_think_block = false;
-                                // Show AGENT RESPONSE banner after thinking ends
-                                sink.emit(EngineEvent::ResponseStart);
-                                response_banner_shown = true;
-                                continue; // process remaining buffer
-                            } else {
-                                // Still in think block — just accumulate, don't print yet
-                                // (spinner provides progress feedback while we buffer)
-                                break;
-                            }
-                        } else {
-                            // Looking for <think>
-                            if let Some(start_pos) = think_buffer.find("<think>") {
-                                // Render text before <think> tag with markdown
-                                let before = &think_buffer[..start_pos];
-                                if !before.is_empty() {
-                                    if !response_banner_shown && !before.trim().is_empty() {
-                                        sink.emit(EngineEvent::ResponseStart);
-                                        response_banner_shown = true;
-                                    }
-                                    md.push(before);
-                                }
-                                // Show THINKING banner
-                                sink.emit(EngineEvent::ThinkingStart);
-                                think_buffer = think_buffer[start_pos + 7..].to_string();
-                                in_think_block = true;
-                                continue; // process remaining buffer
-                            } else {
-                                // No think tag — check if buffer might contain
-                                // a partial "<think" at the end
-                                let safe_len =
-                                    think_buffer.rfind('<').unwrap_or(think_buffer.len());
-                                if safe_len > 0 {
-                                    let safe = &think_buffer[..safe_len];
-                                    if !response_banner_shown && !safe.trim().is_empty() {
-                                        sink.emit(EngineEvent::ResponseStart);
-                                        response_banner_shown = true;
-                                    }
-                                    md.push(safe);
-                                    think_buffer = think_buffer[safe_len..].to_string();
-                                }
-                                break;
-                            }
-                        }
-                    }
+                    sink.emit(EngineEvent::TextDelta {
+                        text: delta.clone(),
+                    });
                 }
                 StreamChunk::ThinkingDelta(delta) => {
-                    // Buffer — rendered as a complete block once thinking finishes
+                    // Buffer thinking — emit as a block when text or tool calls start
+                    if !thinking_banner_shown {
+                        spinner.finish_and_clear();
+                        sink.emit(EngineEvent::ThinkingStart);
+                        thinking_banner_shown = true;
+                    }
+                    sink.emit(EngineEvent::ThinkingDelta {
+                        text: delta.clone(),
+                    });
                     native_think_buf.push_str(&delta);
                 }
                 StreamChunk::ToolCalls(tcs) => {
@@ -309,14 +261,8 @@ pub async fn inference_loop(
             }
         }
 
-        // Flush remaining buffer
-        if !think_buffer.is_empty() && !in_think_block {
-            if !response_banner_shown && !think_buffer.trim().is_empty() {
-                sink.emit(EngineEvent::ResponseStart);
-            }
-            md.push(&think_buffer);
-        }
-        md.flush();
+        // Flush remaining text
+        sink.emit(EngineEvent::TextDone);
 
         // If we never showed the AGENT RESPONSE banner (no text or only thinking),
         // and there's non-thinking text, show it now

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -5,6 +5,7 @@
 pub mod anthropic;
 pub mod gemini;
 pub mod openai_compat;
+pub mod think_tag_filter;
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/providers/openai_compat.rs
+++ b/src/providers/openai_compat.rs
@@ -356,6 +356,7 @@ impl LlmProvider for OpenAiCompatProvider {
             let mut buffer = String::new();
             let mut tool_calls: Vec<(String, String, String)> = Vec::new(); // (id, name, args)
             let mut final_usage = TokenUsage::default();
+            let mut think_filter = super::think_tag_filter::ThinkTagFilter::new();
 
             while let Some(chunk_result) = byte_stream.next().await {
                 let Ok(bytes) = chunk_result else { break };
@@ -379,6 +380,9 @@ impl LlmProvider for OpenAiCompatProvider {
                                 })
                                 .collect();
                             let _ = tx.send(StreamChunk::ToolCalls(tcs)).await;
+                        }
+                        for filtered in think_filter.flush() {
+                            let _ = tx.send(filtered).await;
                         }
                         let _ = tx.send(StreamChunk::Done(final_usage.clone())).await;
                         return;
@@ -405,11 +409,15 @@ impl LlmProvider for OpenAiCompatProvider {
                             let _ = tx.send(StreamChunk::ThinkingDelta(reasoning.clone())).await;
                         }
 
-                        // Text delta
+                        // Text delta — run through <think> tag filter
                         if let Some(content) = &choice.delta.content
                             && !content.is_empty()
                         {
-                            let _ = tx.send(StreamChunk::TextDelta(content.clone())).await;
+                            for filtered in
+                                think_filter.process(StreamChunk::TextDelta(content.clone()))
+                            {
+                                let _ = tx.send(filtered).await;
+                            }
                         }
 
                         // Tool call deltas — accumulate
@@ -449,6 +457,10 @@ impl LlmProvider for OpenAiCompatProvider {
                     })
                     .collect();
                 let _ = tx.send(StreamChunk::ToolCalls(tcs)).await;
+            }
+            // Flush any remaining content in the <think> tag filter
+            for filtered in think_filter.flush() {
+                let _ = tx.send(filtered).await;
             }
             let _ = tx.send(StreamChunk::Done(final_usage)).await;
         });

--- a/src/providers/think_tag_filter.rs
+++ b/src/providers/think_tag_filter.rs
@@ -1,0 +1,231 @@
+//! `<think>` tag filter for streaming LLM responses.
+//!
+//! Some models (DeepSeek-R1, Qwen QwQ) embed reasoning inside `<think>...</think>`
+//! XML tags in their regular text output. This filter detects these tags in the
+//! streaming token stream and converts them to proper `ThinkingDelta` chunks.
+//!
+//! This runs at the **provider layer** so the inference engine only sees typed
+//! `StreamChunk` variants — no string parsing needed upstream.
+
+use crate::providers::StreamChunk;
+
+/// A streaming filter that converts `<think>` tags into `ThinkingDelta` chunks.
+///
+/// Feed it `StreamChunk::TextDelta` chunks and it emits a transformed stream
+/// where content inside `<think>...</think>` becomes `ThinkingDelta` instead.
+pub struct ThinkTagFilter {
+    buffer: String,
+    in_think_block: bool,
+}
+
+impl ThinkTagFilter {
+    pub fn new() -> Self {
+        Self {
+            buffer: String::new(),
+            in_think_block: false,
+        }
+    }
+
+    /// Process a stream chunk. Returns zero or more output chunks.
+    ///
+    /// Most of the time this returns a single chunk, but when a `<think>` or
+    /// `</think>` tag spans a chunk boundary, it may return multiple chunks
+    /// or hold content until the next call.
+    pub fn process(&mut self, chunk: StreamChunk) -> Vec<StreamChunk> {
+        match chunk {
+            StreamChunk::TextDelta(delta) => self.process_text(&delta),
+            // Pass everything else through unchanged
+            other => vec![other],
+        }
+    }
+
+    /// Flush any remaining buffered content (call when stream ends).
+    pub fn flush(&mut self) -> Vec<StreamChunk> {
+        if self.buffer.is_empty() {
+            return vec![];
+        }
+        let remaining = std::mem::take(&mut self.buffer);
+        if self.in_think_block {
+            // Unclosed <think> block — emit as thinking
+            vec![StreamChunk::ThinkingDelta(remaining)]
+        } else {
+            vec![StreamChunk::TextDelta(remaining)]
+        }
+    }
+
+    fn process_text(&mut self, delta: &str) -> Vec<StreamChunk> {
+        self.buffer.push_str(delta);
+        let mut output = Vec::new();
+
+        loop {
+            if self.in_think_block {
+                // Looking for </think>
+                if let Some(end_pos) = self.buffer.find("</think>") {
+                    let thinking = self.buffer[..end_pos].to_string();
+                    self.buffer = self.buffer[end_pos + 8..].to_string();
+                    self.in_think_block = false;
+                    if !thinking.is_empty() {
+                        output.push(StreamChunk::ThinkingDelta(thinking));
+                    }
+                    continue; // process remaining buffer
+                } else {
+                    // Still accumulating thinking content.
+                    // Emit what we have so far as thinking (for progressive display)
+                    // but keep the last 8 chars in case "</think>" spans chunks.
+                    let safe_len = self.buffer.len().saturating_sub(8);
+                    if safe_len > 0 {
+                        let safe = self.buffer[..safe_len].to_string();
+                        self.buffer = self.buffer[safe_len..].to_string();
+                        output.push(StreamChunk::ThinkingDelta(safe));
+                    }
+                    break;
+                }
+            } else {
+                // Looking for <think>
+                if let Some(start_pos) = self.buffer.find("<think>") {
+                    let before = self.buffer[..start_pos].to_string();
+                    self.buffer = self.buffer[start_pos + 7..].to_string();
+                    self.in_think_block = true;
+                    if !before.is_empty() {
+                        output.push(StreamChunk::TextDelta(before));
+                    }
+                    continue; // process remaining buffer
+                } else {
+                    // No <think> tag found. Emit safe content, keeping
+                    // the last 7 chars in case "<think>" spans chunks.
+                    let safe_len = self.buffer.len().saturating_sub(7);
+                    if safe_len > 0 {
+                        let safe = self.buffer[..safe_len].to_string();
+                        self.buffer = self.buffer[safe_len..].to_string();
+                        output.push(StreamChunk::TextDelta(safe));
+                    }
+                    break;
+                }
+            }
+        }
+
+        output
+    }
+}
+
+impl Default for ThinkTagFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_think_tags() {
+        let mut filter = ThinkTagFilter::new();
+        let chunks = filter.process(StreamChunk::TextDelta("Hello world".into()));
+        let flushed = filter.flush();
+        let all: Vec<_> = chunks.into_iter().chain(flushed).collect();
+        let text: String = all
+            .iter()
+            .filter_map(|c| match c {
+                StreamChunk::TextDelta(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "Hello world");
+    }
+
+    #[test]
+    fn test_think_block_single_chunk() {
+        let mut filter = ThinkTagFilter::new();
+        let chunks = filter.process(StreamChunk::TextDelta(
+            "<think>reasoning here</think>answer".into(),
+        ));
+        let flushed = filter.flush();
+        let all: Vec<_> = chunks.into_iter().chain(flushed).collect();
+
+        let thinking: Vec<&str> = all
+            .iter()
+            .filter_map(|c| match c {
+                StreamChunk::ThinkingDelta(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        let text: Vec<&str> = all
+            .iter()
+            .filter_map(|c| match c {
+                StreamChunk::TextDelta(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(thinking.join(""), "reasoning here");
+        assert_eq!(text.join(""), "answer");
+    }
+
+    #[test]
+    fn test_think_block_across_chunks() {
+        let mut filter = ThinkTagFilter::new();
+        let mut all = Vec::new();
+        all.extend(filter.process(StreamChunk::TextDelta("<thi".into())));
+        all.extend(filter.process(StreamChunk::TextDelta("nk>reas".into())));
+        all.extend(filter.process(StreamChunk::TextDelta("oning</th".into())));
+        all.extend(filter.process(StreamChunk::TextDelta("ink>answer".into())));
+        all.extend(filter.flush());
+
+        let thinking: String = all
+            .iter()
+            .filter_map(|c| match c {
+                StreamChunk::ThinkingDelta(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        let text: String = all
+            .iter()
+            .filter_map(|c| match c {
+                StreamChunk::TextDelta(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(thinking, "reasoning");
+        assert_eq!(text, "answer");
+    }
+
+    #[test]
+    fn test_passthrough_non_text_chunks() {
+        let mut filter = ThinkTagFilter::new();
+        let chunks = filter.process(StreamChunk::ThinkingDelta("native thinking".into()));
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(&chunks[0], StreamChunk::ThinkingDelta(t) if t == "native thinking"));
+    }
+
+    #[test]
+    fn test_multiple_think_blocks() {
+        let mut filter = ThinkTagFilter::new();
+        let mut all = Vec::new();
+        all.extend(filter.process(StreamChunk::TextDelta(
+            "intro<think>thought1</think>middle<think>thought2</think>end".into(),
+        )));
+        all.extend(filter.flush());
+
+        let thinking: String = all
+            .iter()
+            .filter_map(|c| match c {
+                StreamChunk::ThinkingDelta(t) => Some(t.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        let text: String = all
+            .iter()
+            .filter_map(|c| match c {
+                StreamChunk::TextDelta(t) => Some(t.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+
+        assert_eq!(thinking, "thought1thought2");
+        assert_eq!(text, "intromiddleend");
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #41. Completes the v0.1.x engine extraction.

The approval flow is now fully routed through `EngineSink::request_approval()`, removing the last direct UI coupling from the inference engine.

### What changed

Added `request_approval()` method to `EngineSink`:
```rust
fn request_approval(
    &self,
    tool_name: &str,
    detail: &str,
    preview: Option<&str>,
    whitelist_hint: Option<&str>,
) -> ApprovalDecision;
```

| Sink | Behavior |
|---|---|
| `CliSink` | Delegates to `confirm::confirm_tool_action()` (exact current UX) |
| `TestSink` | Auto-approves everything |
| Future `AcpSink` | Sends WebSocket message, awaits remote client response |

Replaced both approval call sites in `inference.rs`:
- `execute_tools_sequential`: normal tool approval
- `execute_sub_agent`: sub-agent tool approval

`inference.rs` no longer imports `confirm::Confirmation`.

### Engine decoupling status

| Coupling | Before | After |
|---|---|---|
| `display::` calls | 19 in inference.rs | 0 (`sink.emit()`) |
| `confirm::` blocking calls | 2 in inference.rs | 0 (`sink.request_approval()`) |
| `println!()` calls | ~15 in inference.rs | ~15 (incremental, future PRs) |
| `MarkdownStreamer` | Direct stdout | Direct stdout (future PR) |

### Testing
- All 351 tests pass, clippy clean
- Zero behavioral change