### PR TITLE
refactor: KodaAgent + KodaSession structs (Phase 3 of #50)

### DIFF
--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -5,14 +5,11 @@
 use crate::input::{self, KodaHelper};
 use koda_core::agent::KodaAgent;
 use koda_core::approval::{self, ApprovalMode};
-use koda_core::config::{KodaConfig, ProviderType};
+use koda_core::config::KodaConfig;
 use koda_core::db::{Database, Role};
 use koda_core::providers::LlmProvider;
 use koda_core::session::KodaSession;
 
-/// Number of recent messages to preserve during compaction.
-/// Keeps the user's last question + the assistant's last answer intact.
-const COMPACT_PRESERVE_COUNT: usize = 4;
 use crate::repl::{self, ReplAction};
 use crate::tui::{self, SelectOption};
 
@@ -30,7 +27,7 @@ pub async fn run(
     version_check: tokio::task::JoinHandle<Option<String>>,
 ) -> Result<()> {
     let provider: Arc<RwLock<Box<dyn LlmProvider>>> =
-        Arc::new(RwLock::new(create_provider(&config)));
+        Arc::new(RwLock::new(crate::commands::create_provider(&config)));
 
     // Auto-detect the serving model for local providers
     if config.model == "auto-detect" {
@@ -212,11 +209,18 @@ pub async fn run(
                     continue;
                 }
                 ReplAction::SetupProvider(ptype, base_url) => {
-                    handle_setup_provider(&mut config, &provider, &mut rl, ptype, base_url).await;
+                    crate::commands::handle_setup_provider(
+                        &mut config,
+                        &provider,
+                        &mut rl,
+                        ptype,
+                        base_url,
+                    )
+                    .await;
                     continue;
                 }
                 ReplAction::PickProvider => {
-                    handle_pick_provider(&mut config, &provider, &mut rl).await;
+                    crate::commands::handle_pick_provider(&mut config, &provider, &mut rl).await;
                     continue;
                 }
 
@@ -367,11 +371,19 @@ pub async fn run(
                     continue;
                 }
                 ReplAction::Compact => {
-                    handle_compact(&session.db, &session.id, &config, &provider, false).await;
+                    crate::commands::handle_compact(
+                        &session.db,
+                        &session.id,
+                        &config,
+                        &provider,
+                        false,
+                    )
+                    .await;
                     continue;
                 }
                 ReplAction::McpCommand(ref args) => {
-                    handle_mcp_command(args, &agent.mcp_registry, &project_root).await;
+                    crate::commands::handle_mcp_command(args, &agent.mcp_registry, &project_root)
+                        .await;
                     continue;
                 }
                 ReplAction::SetTrust(mode_name) => {
@@ -380,7 +392,7 @@ pub async fn run(
                         ApprovalMode::parse(name)
                     } else {
                         // Interactive picker
-                        pick_trust_mode(approval::read_mode(&shared_mode))
+                        crate::commands::pick_trust_mode(approval::read_mode(&shared_mode))
                     };
                     if let Some(m) = new_mode {
                         approval::set_mode(&shared_mode, m);
@@ -479,7 +491,14 @@ pub async fn run(
                     println!(
                         "  \x1b[36m\u{1f43b} Context at {ctx_pct}% — auto-compacting...\x1b[0m"
                     );
-                    handle_compact(&session.db, &session.id, &config, &provider, true).await;
+                    crate::commands::handle_compact(
+                        &session.db,
+                        &session.id,
+                        &config,
+                        &provider,
+                        true,
+                    )
+                    .await;
                 }
             }
         }
@@ -499,547 +518,7 @@ pub async fn run(
     Ok(())
 }
 
-// ── Headless mode ──────────────────────────────────────────────
-
-/// Run a single prompt and exit. Returns process exit code (0 = success).
-pub async fn run_headless(
-    project_root: PathBuf,
-    config: KodaConfig,
-    db: Database,
-    session_id: String,
-    prompt: String,
-    output_format: &str,
-) -> Result<i32> {
-    // Build agent (no MCP in headless for speed) and session
-    let agent = Arc::new(KodaAgent::new(&config, project_root.clone()).await?);
-    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<koda_core::engine::EngineCommand>(32);
-    let mut session = KodaSession::new(session_id, agent, db, &config, ApprovalMode::Yolo);
-
-    // Process @file references and images
-    let processed = input::process_input(&prompt, &project_root);
-    let user_message = if let Some(context) = input::format_context_files(&processed.context_files)
-    {
-        format!("{}\n\n{context}", processed.prompt)
-    } else {
-        processed.prompt.clone()
-    };
-
-    let pending_images = if processed.images.is_empty() {
-        None
-    } else {
-        Some(processed.images)
-    };
-
-    session
-        .db
-        .insert_message(
-            &session.id,
-            &Role::User,
-            Some(&user_message),
-            None,
-            None,
-            None,
-        )
-        .await?;
-
-    let cli_sink = crate::sink::CliSink::new(cmd_tx);
-    let result = session
-        .run_turn(
-            &config,
-            pending_images,
-            &cli_sink,
-            &mut cmd_rx,
-            &crate::app::cli_loop_continue_prompt,
-        )
-        .await;
-
-    // For JSON output, wrap the last assistant response
-    if output_format == "json" {
-        let last_response = session
-            .db
-            .last_assistant_message(&session.id)
-            .await
-            .unwrap_or_default();
-        let json = serde_json::json!({
-            "success": result.is_ok(),
-            "response": last_response,
-            "session_id": session.id,
-            "model": config.model,
-        });
-        println!("{}", serde_json::to_string_pretty(&json)?);
-    }
-
-    match result {
-        Ok(()) => Ok(0),
-        Err(e) => {
-            eprintln!("Error: {e}");
-            Ok(1)
-        }
-    }
-}
-
-// ── Compact handler ───────────────────────────────────────────
-
-/// Compact the conversation by summarizing history via the LLM.
-/// When `silent` is true (auto-compact), suppresses the "too short" message.
-///
-/// Improvements over v1:
-/// - Preserves the most recent messages (Fix 1)
-/// - Inserts summary as `system` role, not `user` (Fix 3)
-/// - Adds a continuation instruction for the LLM (Fix 2)
-/// - Checks for pending tool calls before proceeding (Fix 5)
-/// - Uses a structured summarization prompt (Fix 6)
-async fn handle_compact(
-    db: &Database,
-    session_id: &str,
-    config: &KodaConfig,
-    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
-    silent: bool,
-) {
-    use koda_core::providers::ChatMessage;
-
-    // Fix 5: Defer compaction if tool calls are pending
-    if let Ok(true) = db.has_pending_tool_calls(session_id).await {
-        if !silent {
-            println!("  \x1b[33mTool calls are still pending — deferring compact.\x1b[0m");
-        }
-        return;
-    }
-
-    // Load current conversation
-    let history = match db.load_context(session_id, config.max_context_tokens).await {
-        Ok(msgs) => msgs,
-        Err(e) => {
-            if !silent {
-                println!("  \x1b[31mError loading conversation: {e}\x1b[0m");
-            }
-            return;
-        }
-    };
-
-    if history.len() < 4 {
-        if !silent {
-            println!(
-                "  \x1b[90mConversation is too short to compact ({} messages).\x1b[0m",
-                history.len()
-            );
-        }
-        return;
-    }
-
-    // Format the conversation for summarization
-    let mut conversation_text = String::new();
-    for msg in &history {
-        let role = msg.role.as_str();
-        if let Some(ref content) = msg.content {
-            // Cap individual messages to avoid blowing the summary prompt
-            let truncated: String = content.chars().take(2000).collect();
-            conversation_text.push_str(&format!("[{role}]: {truncated}\n\n"));
-        }
-        if let Some(ref tool_calls) = msg.tool_calls {
-            let truncated: String = tool_calls.chars().take(500).collect();
-            conversation_text.push_str(&format!("[{role} tool_calls]: {truncated}\n\n"));
-        }
-    }
-
-    // Cap total conversation text
-    if conversation_text.len() > 20_000 {
-        let mut end = 20_000;
-        while end > 0 && !conversation_text.is_char_boundary(end) {
-            end -= 1;
-        }
-        conversation_text.truncate(end);
-        conversation_text.push_str("\n\n[...truncated for summarization...]");
-    }
-
-    println!();
-    println!(
-        "  \x1b[36m\u{1f43b} Compacting {} messages (preserving last {})...\x1b[0m",
-        history.len(),
-        COMPACT_PRESERVE_COUNT,
-    );
-
-    // Fix 6: Structured summarization prompt preserving code-relevant context
-    let summary_prompt = format!(
-        "Summarize the conversation below. This summary will replace the older messages \
-         so an AI assistant can continue the session seamlessly.\n\
-         \n\
-         Preserve ALL of the following — do NOT omit any section:\n\
-         \n\
-         1. **User Intent** — Every goal, request, and requirement the user stated.\n\
-         2. **Key Decisions** — Decisions made and their rationale.\n\
-         3. **Files & Code** — Every file created, modified, or deleted. Include file paths, \n\
-            key function/struct names, and the purpose of each change.\n\
-         4. **Errors & Fixes** — Bugs encountered, error messages, and how they were resolved.\n\
-         5. **Current State** — What is working, what has been tested, what the project \n\
-            looks like right now.\n\
-         6. **Pending Tasks** — Anything unfinished or explicitly deferred.\n\
-         7. **Next Step** — Only if one was clearly stated or implied.\n\
-         \n\
-         Use concise bullet points. Do not add new ideas or suggestions.\n\
-         \n\
-         ---\n\n{conversation_text}"
-    );
-
-    let messages = vec![ChatMessage::text("user", &summary_prompt)];
-
-    // Call the LLM for the summary (no tools, no streaming)
-    let prov = provider.read().await;
-    let response = match prov.chat(&messages, &[], &config.model_settings).await {
-        Ok(r) => r,
-        Err(e) => {
-            println!("  \x1b[31mFailed to generate summary: {e}\x1b[0m");
-            return;
-        }
-    };
-
-    let summary = match response.content {
-        Some(text) if !text.trim().is_empty() => text,
-        _ => {
-            println!("  \x1b[31mLLM returned an empty summary. Aborting compact.\x1b[0m");
-            return;
-        }
-    };
-
-    // Fix 3: Summary is wrapped clearly for the LLM context (inserted as system role in DB)
-    let compact_message = format!("[Compacted conversation summary]\n\n{summary}");
-
-    // Fix 1: Preserve recent messages; Fix 2 & 3: DB inserts system + assistant continuation
-    match db
-        .compact_session(session_id, &compact_message, COMPACT_PRESERVE_COUNT)
-        .await
-    {
-        Ok(deleted) => {
-            let summary_tokens = summary.len() / 4;
-            println!(
-                "  \x1b[32m\u{2713}\x1b[0m Compacted {deleted} messages → ~{summary_tokens} tokens"
-            );
-            println!(
-                "  \x1b[90mConversation context has been summarized. Continue as normal!\x1b[0m"
-            );
-        }
-        Err(e) => {
-            println!("  \x1b[31mFailed to compact session: {e}\x1b[0m");
-        }
-    }
-    println!();
-}
-
-// ── MCP command handler ──────────────────────────────────────
-
-/// Handle `/mcp` subcommands: status, add, remove, restart.
-async fn handle_mcp_command(
-    args: &str,
-    mcp_registry: &Arc<tokio::sync::RwLock<koda_core::mcp::McpRegistry>>,
-    project_root: &std::path::Path,
-) {
-    let parts: Vec<&str> = args.splitn(3, ' ').collect();
-    let subcommand = parts.first().map(|s| s.trim()).unwrap_or("");
-
-    match subcommand {
-        "" | "status" => {
-            // Show MCP server status
-            let registry = mcp_registry.read().await;
-            let servers = registry.server_info();
-            println!();
-            if servers.is_empty() {
-                println!("  \x1b[90mNo MCP servers connected.\x1b[0m");
-                println!(
-                    "  \x1b[90mAdd servers via .mcp.json or /mcp add <name> <command> [args...]\x1b[0m"
-                );
-            } else {
-                println!("  \x1b[1m\u{1f50c} MCP Servers\x1b[0m");
-                println!();
-                for server in &servers {
-                    let cmd = if server.args.is_empty() {
-                        server.command.clone()
-                    } else {
-                        format!("{} {}", server.command, server.args.join(" "))
-                    };
-                    println!(
-                        "  \x1b[32m\u{25cf}\x1b[0m \x1b[1m{}\x1b[0m \u{2014} {} tool(s)",
-                        server.name, server.tool_count
-                    );
-                    println!("    \x1b[90m{cmd}\x1b[0m");
-                    for tool_name in &server.tool_names {
-                        println!("    \x1b[36m\u{2022}\x1b[0m {tool_name}");
-                    }
-                }
-            }
-            println!();
-        }
-
-        "add" => {
-            // /mcp add <name> <command> [args...]
-            let rest = args.strip_prefix("add").unwrap_or("").trim();
-            let add_parts: Vec<&str> = rest.splitn(2, ' ').collect();
-            if add_parts.len() < 2 {
-                println!("  \x1b[33mUsage: /mcp add <name> <command> [args...]\x1b[0m");
-                println!(
-                    "  \x1b[90mExample: /mcp add filesystem npx -y @modelcontextprotocol/server-filesystem /tmp\x1b[0m"
-                );
-                return;
-            }
-            let name = add_parts[0].to_string();
-            let cmd_parts: Vec<&str> = add_parts[1].split_whitespace().collect();
-            let command = cmd_parts[0].to_string();
-            let cmd_args: Vec<String> = cmd_parts[1..].iter().map(|s| s.to_string()).collect();
-
-            let config = koda_core::mcp::config::McpServerConfig {
-                command: command.clone(),
-                args: cmd_args,
-                env: std::collections::HashMap::new(),
-                timeout: None,
-            };
-
-            // Save to .mcp.json
-            if let Err(e) =
-                koda_core::mcp::config::save_server_to_project(project_root, &name, &config)
-            {
-                println!("  \x1b[31mFailed to save config: {e}\x1b[0m");
-                return;
-            }
-
-            // Connect
-            println!("  \x1b[36m\u{1f50c} Connecting to '{name}'...\x1b[0m");
-            let mut registry = mcp_registry.write().await;
-            match registry.add_server(name.clone(), config).await {
-                Ok(()) => {
-                    let tool_count = registry
-                        .server_info()
-                        .iter()
-                        .find(|s| s.name == name)
-                        .map(|s| s.tool_count)
-                        .unwrap_or(0);
-                    println!(
-                        "  \x1b[32m\u{2713}\x1b[0m Added '{}' ({} tools). Saved to .mcp.json",
-                        name, tool_count
-                    );
-                }
-                Err(e) => {
-                    println!("  \x1b[31m\u{2717}\x1b[0m Failed to connect: {e}");
-                }
-            }
-        }
-
-        "remove" => {
-            let name = args.strip_prefix("remove").unwrap_or("").trim();
-            if name.is_empty() {
-                println!("  \x1b[33mUsage: /mcp remove <name>\x1b[0m");
-                return;
-            }
-            let mut registry = mcp_registry.write().await;
-            if registry.remove_server(name) {
-                // Also remove from .mcp.json
-                let _ = koda_core::mcp::config::remove_server_from_project(project_root, name);
-                println!("  \x1b[32m\u{2713}\x1b[0m Removed MCP server '{name}'");
-            } else {
-                println!("  \x1b[31mMCP server '{name}' not found\x1b[0m");
-            }
-        }
-
-        "restart" => {
-            let name = args.strip_prefix("restart").unwrap_or("").trim();
-            let mut registry = mcp_registry.write().await;
-            if name.is_empty() {
-                println!("  \x1b[36m\u{1f50c} Restarting all MCP servers...\x1b[0m");
-                registry.restart_all(project_root).await;
-                println!("  \x1b[32m\u{2713}\x1b[0m Done");
-            } else {
-                println!("  \x1b[36m\u{1f50c} Restarting '{name}'...\x1b[0m");
-                match registry.restart_server(name, project_root).await {
-                    Ok(()) => println!("  \x1b[32m\u{2713}\x1b[0m Restarted '{name}'"),
-                    Err(e) => println!("  \x1b[31m\u{2717}\x1b[0m Failed: {e}"),
-                }
-            }
-        }
-
-        other => {
-            println!("  \x1b[33mUnknown MCP command: {other}\x1b[0m");
-            println!("  \x1b[90mUsage: /mcp [status|add|remove|restart]\x1b[0m");
-        }
-    }
-}
-
-// ── Provider setup handlers ───────────────────────────────────
-
-async fn handle_setup_provider(
-    config: &mut KodaConfig,
-    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
-    rl: &mut rustyline::Editor<KodaHelper, rustyline::history::DefaultHistory>,
-    ptype: ProviderType,
-    base_url: String,
-) {
-    let env_name = ptype.env_key_name();
-    let key_missing = ptype.requires_api_key() && !koda_core::runtime_env::is_set(env_name);
-    let is_same_provider = ptype == config.provider_type;
-
-    config.provider_type = ptype.clone();
-    config.base_url = base_url;
-    config.model = ptype.default_model().to_string();
-    config.model_settings.model = config.model.clone();
-
-    if key_missing || (is_same_provider && ptype.requires_api_key()) {
-        let prompt_msg = if is_same_provider {
-            format!(
-                "  Update {} API key (enter to keep current): ",
-                config.provider_type
-            )
-        } else {
-            println!("  \x1b[33m{}\x1b[0m is not set.", env_name);
-            format!("  Paste your {} API key: ", config.provider_type)
-        };
-        match rl.readline(&prompt_msg) {
-            Ok(key) => {
-                let key = key.trim().to_string();
-                if key.is_empty() {
-                    if !is_same_provider {
-                        println!("  \x1b[31mNo key provided, provider not changed.\x1b[0m");
-                        return;
-                    }
-                } else {
-                    koda_core::runtime_env::set(env_name, &key);
-                    let masked = koda_core::keystore::mask_key(&key);
-                    println!(
-                        "  \x1b[32m\u{2713}\x1b[0m {} set to \x1b[90m{masked}\x1b[0m",
-                        env_name
-                    );
-                    if let Ok(mut store) = koda_core::keystore::KeyStore::load() {
-                        store.set(env_name, &key);
-                        if let Err(e) = store.save() {
-                            println!("  \x1b[33m\u{26a0} Could not persist key: {e}\x1b[0m");
-                        } else if let Ok(path) = koda_core::keystore::KeyStore::keys_path() {
-                            println!(
-                                "  \x1b[32m\u{2713}\x1b[0m Saved to \x1b[90m{}\x1b[0m",
-                                path.display()
-                            );
-                        }
-                    }
-                }
-            }
-            Err(_) => {
-                println!("  \x1b[31mProvider switch cancelled.\x1b[0m");
-                return;
-            }
-        }
-    } else if !ptype.requires_api_key() {
-        let default_url = ptype.default_base_url();
-        let prompt_msg = format!("  Enter {} URL (enter for {}): ", ptype, default_url);
-        match rl.readline(&prompt_msg) {
-            Ok(url) => {
-                let url = url.trim();
-                if !url.is_empty() {
-                    config.base_url = url.to_string();
-                } else {
-                    config.base_url = default_url.to_string();
-                }
-                println!(
-                    "  \x1b[32m\u{2713}\x1b[0m URL set to \x1b[36m{}\x1b[0m",
-                    config.base_url
-                );
-            }
-            Err(_) => {
-                println!("  \x1b[31mProvider switch cancelled.\x1b[0m");
-                return;
-            }
-        }
-    }
-
-    *provider.write().await = create_provider(config);
-    println!(
-        "  \x1b[32m\u{2713}\x1b[0m Provider: \x1b[36m{}\x1b[0m",
-        config.provider_type
-    );
-
-    let prov = provider.read().await;
-    match prov.list_models().await {
-        Ok(models) => {
-            // Auto-select first model from API instead of using hardcoded default
-            if let Some(first) = models.first() {
-                config.model = first.id.clone();
-                config.model_settings.model = config.model.clone();
-            }
-            println!("  \x1b[32m\u{2713}\x1b[0m Connection verified! Available models:");
-            for m in &models {
-                let current = if m.id == config.model {
-                    " \x1b[32m\u{25c0} selected\x1b[0m"
-                } else {
-                    ""
-                };
-                println!("      {}{current}", m.id);
-            }
-        }
-        Err(e) => {
-            println!("  \x1b[33m\u{26a0} Could not verify connection: {e}\x1b[0m");
-            println!(
-                "    Model set to: \x1b[36m{}\x1b[0m (unverified)",
-                config.model
-            );
-        }
-    }
-    println!();
-}
-
-async fn handle_pick_provider(
-    config: &mut KodaConfig,
-    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
-    rl: &mut rustyline::Editor<KodaHelper, rustyline::history::DefaultHistory>,
-) {
-    let providers = repl::PROVIDERS;
-    let current_idx = providers
-        .iter()
-        .position(|(key, _, _)| {
-            ProviderType::from_url_or_name("", Some(key)) == config.provider_type
-        })
-        .unwrap_or(0);
-    let options: Vec<SelectOption> = providers
-        .iter()
-        .map(|(_, name, url)| SelectOption::new(*name, *url))
-        .collect();
-
-    let selection = match tui::select("\u{1f43b} Select a provider", &options, current_idx) {
-        Ok(Some(idx)) => idx,
-        Ok(None) => {
-            println!("  \x1b[90mCancelled.\x1b[0m");
-            return;
-        }
-        Err(e) => {
-            println!("  \x1b[31mTUI error: {e}\x1b[0m");
-            return;
-        }
-    };
-
-    let (key, _, _) = providers[selection];
-    let ptype = ProviderType::from_url_or_name("", Some(key));
-    let base_url = ptype.default_base_url().to_string();
-
-    handle_setup_provider(config, provider, rl, ptype, base_url).await;
-}
-
 // ── Utilities ─────────────────────────────────────────────────
-
-/// Interactive trust mode picker (arrow-key menu).
-fn pick_trust_mode(current: ApprovalMode) -> Option<ApprovalMode> {
-    use ApprovalMode::*;
-    let modes = [Plan, Normal, Yolo];
-    let options: Vec<SelectOption> = modes
-        .iter()
-        .map(|m| {
-            let label = match m {
-                Plan => "\u{1f4cb} plan",
-                Normal => "\u{1f43b} normal",
-                Yolo => "\u{26a1} yolo",
-            };
-            SelectOption::new(label, m.description())
-        })
-        .collect();
-
-    let initial = modes.iter().position(|m| *m == current).unwrap_or(1);
-    match tui::select("\u{1f43b} Trust level", &options, initial) {
-        Ok(Some(idx)) => Some(modes[idx]),
-        _ => None,
-    }
-}
 
 fn history_file_path() -> PathBuf {
     let config_dir = std::env::var("XDG_CONFIG_HOME")
@@ -1047,11 +526,6 @@ fn history_file_path() -> PathBuf {
         .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{h}/.config")))
         .unwrap_or_else(|_| ".".to_string());
     PathBuf::from(config_dir).join("koda").join("history")
-}
-
-/// Create an LLM provider from the config.
-pub fn create_provider(config: &KodaConfig) -> Box<dyn LlmProvider> {
-    koda_core::providers::create_provider(config)
 }
 
 /// CLI implementation of the loop-continue prompt.
@@ -1089,32 +563,33 @@ pub fn cli_loop_continue_prompt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use koda_core::config::ProviderType;
 
     #[test]
     fn test_create_provider_openai() {
         let config = KodaConfig::default_for_testing(ProviderType::OpenAI);
-        let provider = create_provider(&config);
+        let provider = crate::commands::create_provider(&config);
         assert_eq!(provider.provider_name(), "openai-compat");
     }
 
     #[test]
     fn test_create_provider_anthropic() {
         let config = KodaConfig::default_for_testing(ProviderType::Anthropic);
-        let provider = create_provider(&config);
+        let provider = crate::commands::create_provider(&config);
         assert_eq!(provider.provider_name(), "anthropic");
     }
 
     #[test]
     fn test_create_provider_lmstudio() {
         let config = KodaConfig::default_for_testing(ProviderType::LMStudio);
-        let provider = create_provider(&config);
+        let provider = crate::commands::create_provider(&config);
         assert_eq!(provider.provider_name(), "openai-compat");
     }
 
     #[test]
     fn test_create_provider_gemini() {
         let config = KodaConfig::default_for_testing(ProviderType::Gemini);
-        let provider = create_provider(&config);
+        let provider = crate::commands::create_provider(&config);
         assert_eq!(provider.provider_name(), "gemini");
     }
 

--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -3,19 +3,18 @@
 //! Handles user input, command dispatch, and delegates to the inference engine.
 
 use crate::input::{self, KodaHelper};
-use koda_core::approval::{self, ApprovalMode, Settings};
+use koda_core::agent::KodaAgent;
+use koda_core::approval::{self, ApprovalMode};
 use koda_core::config::{KodaConfig, ProviderType};
 use koda_core::db::{Database, Role};
-use koda_core::inference;
-use koda_core::memory;
 use koda_core::providers::LlmProvider;
+use koda_core::session::KodaSession;
 
 /// Number of recent messages to preserve during compaction.
 /// Keeps the user's last question + the assistant's last answer intact.
 const COMPACT_PRESERVE_COUNT: usize = 4;
 use crate::repl::{self, ReplAction};
 use crate::tui::{self, SelectOption};
-use koda_core::tools::ToolRegistry;
 
 use anyhow::Result;
 use std::path::PathBuf;
@@ -71,24 +70,18 @@ pub async fn run(
         koda_core::version::print_update_hint(&latest);
     }
 
-    // Initialize MCP servers from .mcp.json configs
-    let mcp_registry = Arc::new(tokio::sync::RwLock::new(koda_core::mcp::McpRegistry::new()));
-    {
-        let mut mcp = mcp_registry.write().await;
-        mcp.start_from_config(&project_root).await;
-    }
-
-    let tools = ToolRegistry::new(project_root.clone()).with_mcp_registry(mcp_registry.clone());
-    let tool_defs = tools.get_definitions(&config.allowed_tools);
-
-    let semantic_memory = memory::load(&project_root)?;
-    let system_prompt =
-        inference::build_system_prompt(&config.system_prompt, &semantic_memory, &config.agents_dir);
+    // Build agent (tools, MCP, system prompt) and session
+    let agent = Arc::new(KodaAgent::new(&config, project_root.clone()).await?);
+    let mut session = KodaSession::new(
+        session_id.clone(),
+        agent.clone(),
+        db,
+        &config,
+        ApprovalMode::Normal,
+    );
 
     // REPL with smart completions
-    // Initialize approval mode and user settings
     let shared_mode = approval::new_shared_mode(ApprovalMode::Normal);
-    let mut settings = Settings::load();
 
     let mut helper = KodaHelper::new(project_root.clone(), shared_mode.clone());
     {
@@ -136,7 +129,6 @@ pub async fn run(
     // Channel for approval responses from CLI → engine
     let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<koda_core::engine::EngineCommand>(32);
     let cli_sink = crate::sink::CliSink::new(cmd_tx);
-    let cancel_token = tokio_util::sync::CancellationToken::new();
 
     loop {
         let input = if let Some(cmd) = pending_command.take() {
@@ -257,7 +249,7 @@ pub async fn run(
                     continue;
                 }
                 ReplAction::ShowCost => {
-                    match db.session_token_usage(&session_id).await {
+                    match session.db.session_token_usage(&session.id).await {
                         Ok(u) => {
                             let total = u.prompt_tokens
                                 + u.completion_tokens
@@ -300,7 +292,7 @@ pub async fn run(
                     continue;
                 }
                 ReplAction::ListSessions => {
-                    match db.list_sessions(10, &project_root).await {
+                    match session.db.list_sessions(10, &project_root).await {
                         Ok(sessions) => {
                             println!();
                             println!("  \x1b[1m\u{1f43b} Recent Sessions\x1b[0m");
@@ -309,7 +301,7 @@ pub async fn run(
                                 println!("  \x1b[90mNo sessions found.\x1b[0m");
                             } else {
                                 for s in &sessions {
-                                    let marker = if s.id == session_id {
+                                    let marker = if s.id == session.id {
                                         " \x1b[32m← current\x1b[0m"
                                     } else {
                                         ""
@@ -334,11 +326,11 @@ pub async fn run(
                     continue;
                 }
                 ReplAction::DeleteSession(ref id) => {
-                    if id == &session_id {
+                    if id == &session.id {
                         println!("  \x1b[31mCannot delete the current session.\x1b[0m");
                     } else {
                         // Match by prefix
-                        match db.list_sessions(100, &project_root).await {
+                        match session.db.list_sessions(100, &project_root).await {
                             Ok(sessions) => {
                                 let matches: Vec<_> =
                                     sessions.iter().filter(|s| s.id.starts_with(id)).collect();
@@ -348,7 +340,7 @@ pub async fn run(
                                     ),
                                     1 => {
                                         let full_id = &matches[0].id;
-                                        match db.delete_session(full_id).await {
+                                        match session.db.delete_session(full_id).await {
                                             Ok(true) => println!(
                                                 "  \x1b[32m\u{2713}\x1b[0m Deleted session {}",
                                                 &full_id[..8]
@@ -375,11 +367,11 @@ pub async fn run(
                     continue;
                 }
                 ReplAction::Compact => {
-                    handle_compact(&db, &session_id, &config, &provider, false).await;
+                    handle_compact(&session.db, &session.id, &config, &provider, false).await;
                     continue;
                 }
                 ReplAction::McpCommand(ref args) => {
-                    handle_mcp_command(args, &mcp_registry, &project_root).await;
+                    handle_mcp_command(args, &agent.mcp_registry, &project_root).await;
                     continue;
                 }
                 ReplAction::SetTrust(mode_name) => {
@@ -431,15 +423,17 @@ pub async fn run(
                 processed.prompt.clone()
             };
 
-        db.insert_message(
-            &session_id,
-            &Role::User,
-            Some(&user_message),
-            None,
-            None,
-            None,
-        )
-        .await?;
+        session
+            .db
+            .insert_message(
+                &session.id,
+                &Role::User,
+                Some(&user_message),
+                None,
+                None,
+                None,
+            )
+            .await?;
 
         // Pass images to inference (they're not stored in DB, only used in-flight)
         let pending_images = if processed.images.is_empty() {
@@ -448,35 +442,27 @@ pub async fn run(
             Some(processed.images)
         };
 
-        // Run the inference loop
-        let prov = provider.read().await;
-        let current_mode = approval::read_mode(&shared_mode);
-        inference::inference_loop(
-            &project_root,
-            &config,
-            &db,
-            &session_id,
-            &system_prompt,
-            prov.as_ref(),
-            &tools,
-            &tool_defs,
-            pending_images,
-            current_mode,
-            &mut settings,
-            &cli_sink,
-            cancel_token.clone(),
-            &mut cmd_rx,
-            &crate::app::cli_loop_continue_prompt,
-        )
-        .await?;
+        // Sync session state from REPL changes (model/provider switching)
+        session.mode = approval::read_mode(&shared_mode);
+        session.update_provider(&config);
+        session
+            .run_turn(
+                &config,
+                pending_images,
+                &cli_sink,
+                &mut cmd_rx,
+                &crate::app::cli_loop_continue_prompt,
+            )
+            .await?;
 
         // Auto-compact when context window gets crowded
         if config.auto_compact_threshold > 0 {
             let ctx_pct = koda_core::context::percentage();
             if ctx_pct >= config.auto_compact_threshold {
                 // Fix 5: Defer compaction if tool calls are still pending
-                let pending = db
-                    .has_pending_tool_calls(&session_id)
+                let pending = session
+                    .db
+                    .has_pending_tool_calls(&session.id)
                     .await
                     .unwrap_or(false);
                 if pending {
@@ -493,7 +479,7 @@ pub async fn run(
                     println!(
                         "  \x1b[36m\u{1f43b} Context at {ctx_pct}% — auto-compacting...\x1b[0m"
                     );
-                    handle_compact(&db, &session_id, &config, &provider, true).await;
+                    handle_compact(&session.db, &session.id, &config, &provider, true).await;
                 }
             }
         }
@@ -506,7 +492,7 @@ pub async fn run(
 
     // Shut down MCP servers
     {
-        let mut mcp = mcp_registry.write().await;
+        let mut mcp = agent.mcp_registry.write().await;
         mcp.shutdown();
     }
 
@@ -524,17 +510,12 @@ pub async fn run_headless(
     prompt: String,
     output_format: &str,
 ) -> Result<i32> {
-    let provider: Arc<RwLock<Box<dyn LlmProvider>>> =
-        Arc::new(RwLock::new(create_provider(&config)));
+    // Build agent (no MCP in headless for speed) and session
+    let agent = Arc::new(KodaAgent::new(&config, project_root.clone()).await?);
+    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<koda_core::engine::EngineCommand>(32);
+    let mut session = KodaSession::new(session_id, agent, db, &config, ApprovalMode::Yolo);
 
-    let tools = koda_core::tools::ToolRegistry::new(project_root.clone());
-    let tool_defs = tools.get_definitions(&config.allowed_tools);
-
-    let semantic_memory = memory::load(&project_root)?;
-    let system_prompt =
-        inference::build_system_prompt(&config.system_prompt, &semantic_memory, &config.agents_dir);
-
-    // Process @file references and images (same as interactive mode)
+    // Process @file references and images
     let processed = input::process_input(&prompt, &project_root);
     let user_message = if let Some(context) = input::format_context_files(&processed.context_files)
     {
@@ -549,50 +530,40 @@ pub async fn run_headless(
         Some(processed.images)
     };
 
-    db.insert_message(
-        &session_id,
-        &Role::User,
-        Some(&user_message),
-        None,
-        None,
-        None,
-    )
-    .await?;
+    session
+        .db
+        .insert_message(
+            &session.id,
+            &Role::User,
+            Some(&user_message),
+            None,
+            None,
+            None,
+        )
+        .await?;
 
-    // Headless mode: use Yolo (no confirmation prompts)
-    let mut settings = Settings::load();
-
-    // Run inference (tools work, streaming prints to stdout)
-    let prov = provider.read().await;
-    let result = inference::inference_loop(
-        &project_root,
-        &config,
-        &db,
-        &session_id,
-        &system_prompt,
-        prov.as_ref(),
-        &tools,
-        &tool_defs,
-        pending_images,
-        ApprovalMode::Yolo,
-        &mut settings,
-        &crate::sink::CliSink::new(tokio::sync::mpsc::channel(32).0),
-        tokio_util::sync::CancellationToken::new(),
-        &mut tokio::sync::mpsc::channel(1).1,
-        &crate::app::cli_loop_continue_prompt,
-    )
-    .await;
+    let cli_sink = crate::sink::CliSink::new(cmd_tx);
+    let result = session
+        .run_turn(
+            &config,
+            pending_images,
+            &cli_sink,
+            &mut cmd_rx,
+            &crate::app::cli_loop_continue_prompt,
+        )
+        .await;
 
     // For JSON output, wrap the last assistant response
     if output_format == "json" {
-        let last_response = db
-            .last_assistant_message(&session_id)
+        let last_response = session
+            .db
+            .last_assistant_message(&session.id)
             .await
             .unwrap_or_default();
         let json = serde_json::json!({
             "success": result.is_ok(),
             "response": last_response,
-            "session_id": session_id,
+            "session_id": session.id,
             "model": config.model,
         });
         println!("{}", serde_json::to_string_pretty(&json)?);

--- a/koda-cli/src/commands.rs
+++ b/koda-cli/src/commands.rs
@@ -1,0 +1,486 @@
+//! REPL command handlers — /compact, /mcp, /provider, /trust.
+//!
+//! Extracted from app.rs to keep each file under 600 lines.
+
+use crate::input::KodaHelper;
+use crate::tui::SelectOption;
+use koda_core::approval::ApprovalMode;
+use koda_core::config::{KodaConfig, ProviderType};
+use koda_core::db::Database;
+use koda_core::providers::LlmProvider;
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Number of recent messages to preserve during compaction.
+const COMPACT_PRESERVE_COUNT: usize = 4;
+
+// ── Compact handler ───────────────────────────────────────────
+
+/// Compact the conversation by summarizing history via the LLM.
+/// When `silent` is true (auto-compact), suppresses the "too short" message.
+///
+/// Improvements over v1:
+/// - Preserves the most recent messages (Fix 1)
+/// - Inserts summary as `system` role, not `user` (Fix 3)
+/// - Adds a continuation instruction for the LLM (Fix 2)
+/// - Checks for pending tool calls before proceeding (Fix 5)
+/// - Uses a structured summarization prompt (Fix 6)
+pub(crate) async fn handle_compact(
+    db: &Database,
+    session_id: &str,
+    config: &KodaConfig,
+    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
+    silent: bool,
+) {
+    use koda_core::providers::ChatMessage;
+
+    // Fix 5: Defer compaction if tool calls are pending
+    if let Ok(true) = db.has_pending_tool_calls(session_id).await {
+        if !silent {
+            println!("  \x1b[33mTool calls are still pending — deferring compact.\x1b[0m");
+        }
+        return;
+    }
+
+    // Load current conversation
+    let history = match db.load_context(session_id, config.max_context_tokens).await {
+        Ok(msgs) => msgs,
+        Err(e) => {
+            if !silent {
+                println!("  \x1b[31mError loading conversation: {e}\x1b[0m");
+            }
+            return;
+        }
+    };
+
+    if history.len() < 4 {
+        if !silent {
+            println!(
+                "  \x1b[90mConversation is too short to compact ({} messages).\x1b[0m",
+                history.len()
+            );
+        }
+        return;
+    }
+
+    // Format the conversation for summarization
+    let mut conversation_text = String::new();
+    for msg in &history {
+        let role = msg.role.as_str();
+        if let Some(ref content) = msg.content {
+            // Cap individual messages to avoid blowing the summary prompt
+            let truncated: String = content.chars().take(2000).collect();
+            conversation_text.push_str(&format!("[{role}]: {truncated}\n\n"));
+        }
+        if let Some(ref tool_calls) = msg.tool_calls {
+            let truncated: String = tool_calls.chars().take(500).collect();
+            conversation_text.push_str(&format!("[{role} tool_calls]: {truncated}\n\n"));
+        }
+    }
+
+    // Cap total conversation text
+    if conversation_text.len() > 20_000 {
+        let mut end = 20_000;
+        while end > 0 && !conversation_text.is_char_boundary(end) {
+            end -= 1;
+        }
+        conversation_text.truncate(end);
+        conversation_text.push_str("\n\n[...truncated for summarization...]");
+    }
+
+    println!();
+    println!(
+        "  \x1b[36m\u{1f43b} Compacting {} messages (preserving last {})...\x1b[0m",
+        history.len(),
+        COMPACT_PRESERVE_COUNT,
+    );
+
+    // Fix 6: Structured summarization prompt preserving code-relevant context
+    let summary_prompt = format!(
+        "Summarize the conversation below. This summary will replace the older messages \
+         so an AI assistant can continue the session seamlessly.\n\
+         \n\
+         Preserve ALL of the following — do NOT omit any section:\n\
+         \n\
+         1. **User Intent** — Every goal, request, and requirement the user stated.\n\
+         2. **Key Decisions** — Decisions made and their rationale.\n\
+         3. **Files & Code** — Every file created, modified, or deleted. Include file paths, \n\
+            key function/struct names, and the purpose of each change.\n\
+         4. **Errors & Fixes** — Bugs encountered, error messages, and how they were resolved.\n\
+         5. **Current State** — What is working, what has been tested, what the project \n\
+            looks like right now.\n\
+         6. **Pending Tasks** — Anything unfinished or explicitly deferred.\n\
+         7. **Next Step** — Only if one was clearly stated or implied.\n\
+         \n\
+         Use concise bullet points. Do not add new ideas or suggestions.\n\
+         \n\
+         ---\n\n{conversation_text}"
+    );
+
+    let messages = vec![ChatMessage::text("user", &summary_prompt)];
+
+    // Call the LLM for the summary (no tools, no streaming)
+    let prov = provider.read().await;
+    let response = match prov.chat(&messages, &[], &config.model_settings).await {
+        Ok(r) => r,
+        Err(e) => {
+            println!("  \x1b[31mFailed to generate summary: {e}\x1b[0m");
+            return;
+        }
+    };
+
+    let summary = match response.content {
+        Some(text) if !text.trim().is_empty() => text,
+        _ => {
+            println!("  \x1b[31mLLM returned an empty summary. Aborting compact.\x1b[0m");
+            return;
+        }
+    };
+
+    // Fix 3: Summary is wrapped clearly for the LLM context (inserted as system role in DB)
+    let compact_message = format!("[Compacted conversation summary]\n\n{summary}");
+
+    // Fix 1: Preserve recent messages; Fix 2 & 3: DB inserts system + assistant continuation
+    match db
+        .compact_session(session_id, &compact_message, COMPACT_PRESERVE_COUNT)
+        .await
+    {
+        Ok(deleted) => {
+            let summary_tokens = summary.len() / 4;
+            println!(
+                "  \x1b[32m\u{2713}\x1b[0m Compacted {deleted} messages → ~{summary_tokens} tokens"
+            );
+            println!(
+                "  \x1b[90mConversation context has been summarized. Continue as normal!\x1b[0m"
+            );
+        }
+        Err(e) => {
+            println!("  \x1b[31mFailed to compact session: {e}\x1b[0m");
+        }
+    }
+    println!();
+}
+
+// ── MCP command handler ──────────────────────────────────────
+
+/// Handle `/mcp` subcommands: status, add, remove, restart.
+pub(crate) async fn handle_mcp_command(
+    args: &str,
+    mcp_registry: &Arc<tokio::sync::RwLock<koda_core::mcp::McpRegistry>>,
+    project_root: &std::path::Path,
+) {
+    let parts: Vec<&str> = args.splitn(3, ' ').collect();
+    let subcommand = parts.first().map(|s| s.trim()).unwrap_or("");
+
+    match subcommand {
+        "" | "status" => {
+            // Show MCP server status
+            let registry = mcp_registry.read().await;
+            let servers = registry.server_info();
+            println!();
+            if servers.is_empty() {
+                println!("  \x1b[90mNo MCP servers connected.\x1b[0m");
+                println!(
+                    "  \x1b[90mAdd servers via .mcp.json or /mcp add <name> <command> [args...]\x1b[0m"
+                );
+            } else {
+                println!("  \x1b[1m\u{1f50c} MCP Servers\x1b[0m");
+                println!();
+                for server in &servers {
+                    let cmd = if server.args.is_empty() {
+                        server.command.clone()
+                    } else {
+                        format!("{} {}", server.command, server.args.join(" "))
+                    };
+                    println!(
+                        "  \x1b[32m\u{25cf}\x1b[0m \x1b[1m{}\x1b[0m \u{2014} {} tool(s)",
+                        server.name, server.tool_count
+                    );
+                    println!("    \x1b[90m{cmd}\x1b[0m");
+                    for tool_name in &server.tool_names {
+                        println!("    \x1b[36m\u{2022}\x1b[0m {tool_name}");
+                    }
+                }
+            }
+            println!();
+        }
+
+        "add" => {
+            // /mcp add <name> <command> [args...]
+            let rest = args.strip_prefix("add").unwrap_or("").trim();
+            let add_parts: Vec<&str> = rest.splitn(2, ' ').collect();
+            if add_parts.len() < 2 {
+                println!("  \x1b[33mUsage: /mcp add <name> <command> [args...]\x1b[0m");
+                println!(
+                    "  \x1b[90mExample: /mcp add filesystem npx -y @modelcontextprotocol/server-filesystem /tmp\x1b[0m"
+                );
+                return;
+            }
+            let name = add_parts[0].to_string();
+            let cmd_parts: Vec<&str> = add_parts[1].split_whitespace().collect();
+            let command = cmd_parts[0].to_string();
+            let cmd_args: Vec<String> = cmd_parts[1..].iter().map(|s| s.to_string()).collect();
+
+            let config = koda_core::mcp::config::McpServerConfig {
+                command: command.clone(),
+                args: cmd_args,
+                env: std::collections::HashMap::new(),
+                timeout: None,
+            };
+
+            // Save to .mcp.json
+            if let Err(e) =
+                koda_core::mcp::config::save_server_to_project(project_root, &name, &config)
+            {
+                println!("  \x1b[31mFailed to save config: {e}\x1b[0m");
+                return;
+            }
+
+            // Connect
+            println!("  \x1b[36m\u{1f50c} Connecting to '{name}'...\x1b[0m");
+            let mut registry = mcp_registry.write().await;
+            match registry.add_server(name.clone(), config).await {
+                Ok(()) => {
+                    let tool_count = registry
+                        .server_info()
+                        .iter()
+                        .find(|s| s.name == name)
+                        .map(|s| s.tool_count)
+                        .unwrap_or(0);
+                    println!(
+                        "  \x1b[32m\u{2713}\x1b[0m Added '{}' ({} tools). Saved to .mcp.json",
+                        name, tool_count
+                    );
+                }
+                Err(e) => {
+                    println!("  \x1b[31m\u{2717}\x1b[0m Failed to connect: {e}");
+                }
+            }
+        }
+
+        "remove" => {
+            let name = args.strip_prefix("remove").unwrap_or("").trim();
+            if name.is_empty() {
+                println!("  \x1b[33mUsage: /mcp remove <name>\x1b[0m");
+                return;
+            }
+            let mut registry = mcp_registry.write().await;
+            if registry.remove_server(name) {
+                // Also remove from .mcp.json
+                let _ = koda_core::mcp::config::remove_server_from_project(project_root, name);
+                println!("  \x1b[32m\u{2713}\x1b[0m Removed MCP server '{name}'");
+            } else {
+                println!("  \x1b[31mMCP server '{name}' not found\x1b[0m");
+            }
+        }
+
+        "restart" => {
+            let name = args.strip_prefix("restart").unwrap_or("").trim();
+            let mut registry = mcp_registry.write().await;
+            if name.is_empty() {
+                println!("  \x1b[36m\u{1f50c} Restarting all MCP servers...\x1b[0m");
+                registry.restart_all(project_root).await;
+                println!("  \x1b[32m\u{2713}\x1b[0m Done");
+            } else {
+                println!("  \x1b[36m\u{1f50c} Restarting '{name}'...\x1b[0m");
+                match registry.restart_server(name, project_root).await {
+                    Ok(()) => println!("  \x1b[32m\u{2713}\x1b[0m Restarted '{name}'"),
+                    Err(e) => println!("  \x1b[31m\u{2717}\x1b[0m Failed: {e}"),
+                }
+            }
+        }
+
+        other => {
+            println!("  \x1b[33mUnknown MCP command: {other}\x1b[0m");
+            println!("  \x1b[90mUsage: /mcp [status|add|remove|restart]\x1b[0m");
+        }
+    }
+}
+
+// ── Provider setup handlers ───────────────────────────────────
+
+pub(crate) async fn handle_setup_provider(
+    config: &mut KodaConfig,
+    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
+    rl: &mut rustyline::Editor<KodaHelper, rustyline::history::DefaultHistory>,
+    ptype: ProviderType,
+    base_url: String,
+) {
+    let env_name = ptype.env_key_name();
+    let key_missing = ptype.requires_api_key() && !koda_core::runtime_env::is_set(env_name);
+    let is_same_provider = ptype == config.provider_type;
+
+    config.provider_type = ptype.clone();
+    config.base_url = base_url;
+    config.model = ptype.default_model().to_string();
+    config.model_settings.model = config.model.clone();
+
+    if key_missing || (is_same_provider && ptype.requires_api_key()) {
+        let prompt_msg = if is_same_provider {
+            format!(
+                "  Update {} API key (enter to keep current): ",
+                config.provider_type
+            )
+        } else {
+            println!("  \x1b[33m{}\x1b[0m is not set.", env_name);
+            format!("  Paste your {} API key: ", config.provider_type)
+        };
+        match rl.readline(&prompt_msg) {
+            Ok(key) => {
+                let key = key.trim().to_string();
+                if key.is_empty() {
+                    if !is_same_provider {
+                        println!("  \x1b[31mNo key provided, provider not changed.\x1b[0m");
+                        return;
+                    }
+                } else {
+                    koda_core::runtime_env::set(env_name, &key);
+                    let masked = koda_core::keystore::mask_key(&key);
+                    println!(
+                        "  \x1b[32m\u{2713}\x1b[0m {} set to \x1b[90m{masked}\x1b[0m",
+                        env_name
+                    );
+                    if let Ok(mut store) = koda_core::keystore::KeyStore::load() {
+                        store.set(env_name, &key);
+                        if let Err(e) = store.save() {
+                            println!("  \x1b[33m\u{26a0} Could not persist key: {e}\x1b[0m");
+                        } else if let Ok(path) = koda_core::keystore::KeyStore::keys_path() {
+                            println!(
+                                "  \x1b[32m\u{2713}\x1b[0m Saved to \x1b[90m{}\x1b[0m",
+                                path.display()
+                            );
+                        }
+                    }
+                }
+            }
+            Err(_) => {
+                println!("  \x1b[31mProvider switch cancelled.\x1b[0m");
+                return;
+            }
+        }
+    } else if !ptype.requires_api_key() {
+        let default_url = ptype.default_base_url();
+        let prompt_msg = format!("  Enter {} URL (enter for {}): ", ptype, default_url);
+        match rl.readline(&prompt_msg) {
+            Ok(url) => {
+                let url = url.trim();
+                if !url.is_empty() {
+                    config.base_url = url.to_string();
+                } else {
+                    config.base_url = default_url.to_string();
+                }
+                println!(
+                    "  \x1b[32m\u{2713}\x1b[0m URL set to \x1b[36m{}\x1b[0m",
+                    config.base_url
+                );
+            }
+            Err(_) => {
+                println!("  \x1b[31mProvider switch cancelled.\x1b[0m");
+                return;
+            }
+        }
+    }
+
+    *provider.write().await = create_provider(config);
+    println!(
+        "  \x1b[32m\u{2713}\x1b[0m Provider: \x1b[36m{}\x1b[0m",
+        config.provider_type
+    );
+
+    let prov = provider.read().await;
+    match prov.list_models().await {
+        Ok(models) => {
+            // Auto-select first model from API instead of using hardcoded default
+            if let Some(first) = models.first() {
+                config.model = first.id.clone();
+                config.model_settings.model = config.model.clone();
+            }
+            println!("  \x1b[32m\u{2713}\x1b[0m Connection verified! Available models:");
+            for m in &models {
+                let current = if m.id == config.model {
+                    " \x1b[32m\u{25c0} selected\x1b[0m"
+                } else {
+                    ""
+                };
+                println!("      {}{current}", m.id);
+            }
+        }
+        Err(e) => {
+            println!("  \x1b[33m\u{26a0} Could not verify connection: {e}\x1b[0m");
+            println!(
+                "    Model set to: \x1b[36m{}\x1b[0m (unverified)",
+                config.model
+            );
+        }
+    }
+    println!();
+}
+
+pub(crate) async fn handle_pick_provider(
+    config: &mut KodaConfig,
+    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
+    rl: &mut rustyline::Editor<KodaHelper, rustyline::history::DefaultHistory>,
+) {
+    let providers = crate::repl::PROVIDERS;
+    let current_idx = providers
+        .iter()
+        .position(|(key, _, _)| {
+            ProviderType::from_url_or_name("", Some(key)) == config.provider_type
+        })
+        .unwrap_or(0);
+    let options: Vec<SelectOption> = providers
+        .iter()
+        .map(|(_, name, url)| SelectOption::new(*name, *url))
+        .collect();
+
+    let selection = match crate::tui::select("\u{1f43b} Select a provider", &options, current_idx) {
+        Ok(Some(idx)) => idx,
+        Ok(None) => {
+            println!("  \x1b[90mCancelled.\x1b[0m");
+            return;
+        }
+        Err(e) => {
+            println!("  \x1b[31mTUI error: {e}\x1b[0m");
+            return;
+        }
+    };
+
+    let (key, _, _) = providers[selection];
+    let ptype = ProviderType::from_url_or_name("", Some(key));
+    let base_url = ptype.default_base_url().to_string();
+
+    handle_setup_provider(config, provider, rl, ptype, base_url).await;
+}
+
+// ── Trust mode picker ───────────────────────────────────────
+
+/// Interactive trust mode picker (arrow-key menu).
+pub(crate) fn pick_trust_mode(current: ApprovalMode) -> Option<ApprovalMode> {
+    use ApprovalMode::*;
+    let modes = [Plan, Normal, Yolo];
+    let options: Vec<SelectOption> = modes
+        .iter()
+        .map(|m| {
+            let label = match m {
+                Plan => "\u{1f4cb} plan",
+                Normal => "\u{1f43b} normal",
+                Yolo => "\u{26a1} yolo",
+            };
+            SelectOption::new(label, m.description())
+        })
+        .collect();
+
+    let initial = modes.iter().position(|m| *m == current).unwrap_or(1);
+    match crate::tui::select("\u{1f43b} Trust level", &options, initial) {
+        Ok(Some(idx)) => Some(modes[idx]),
+        _ => None,
+    }
+}
+
+// ── Provider factory ───────────────────────────────────────
+
+/// Create an LLM provider from the config.
+pub(crate) fn create_provider(config: &KodaConfig) -> Box<dyn LlmProvider> {
+    koda_core::providers::create_provider(config)
+}

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -1,0 +1,88 @@
+//! Headless mode — run a single prompt and exit.
+
+use crate::input;
+use koda_core::agent::KodaAgent;
+use koda_core::approval::ApprovalMode;
+use koda_core::config::KodaConfig;
+use koda_core::db::{Database, Role};
+use koda_core::session::KodaSession;
+
+use anyhow::Result;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Run a single prompt and exit. Returns process exit code (0 = success).
+pub async fn run_headless(
+    project_root: PathBuf,
+    config: KodaConfig,
+    db: Database,
+    session_id: String,
+    prompt: String,
+    output_format: &str,
+) -> Result<i32> {
+    let agent = Arc::new(KodaAgent::new(&config, project_root.clone()).await?);
+    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<koda_core::engine::EngineCommand>(32);
+    let mut session = KodaSession::new(session_id, agent, db, &config, ApprovalMode::Yolo);
+
+    // Process @file references and images
+    let processed = input::process_input(&prompt, &project_root);
+    let user_message = if let Some(context) = input::format_context_files(&processed.context_files)
+    {
+        format!("{}\n\n{context}", processed.prompt)
+    } else {
+        processed.prompt.clone()
+    };
+
+    let pending_images = if processed.images.is_empty() {
+        None
+    } else {
+        Some(processed.images)
+    };
+
+    session
+        .db
+        .insert_message(
+            &session.id,
+            &Role::User,
+            Some(&user_message),
+            None,
+            None,
+            None,
+        )
+        .await?;
+
+    let cli_sink = crate::sink::CliSink::new(cmd_tx);
+    let result = session
+        .run_turn(
+            &config,
+            pending_images,
+            &cli_sink,
+            &mut cmd_rx,
+            &crate::app::cli_loop_continue_prompt,
+        )
+        .await;
+
+    // For JSON output, wrap the last assistant response
+    if output_format == "json" {
+        let last_response = session
+            .db
+            .last_assistant_message(&session.id)
+            .await
+            .unwrap_or_default();
+        let json = serde_json::json!({
+            "success": result.is_ok(),
+            "response": last_response,
+            "session_id": session.id,
+            "model": config.model,
+        });
+        println!("{}", serde_json::to_string_pretty(&json)?);
+    }
+
+    match result {
+        Ok(()) => Ok(0),
+        Err(e) => {
+            eprintln!("Error: {e}");
+            Ok(1)
+        }
+    }
+}

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -3,8 +3,10 @@
 //! CLI entry point. The binary is named `koda` for ergonomics.
 
 mod app;
+mod commands;
 mod confirm;
 mod display;
+mod headless;
 mod highlight;
 mod input;
 mod interrupt;
@@ -127,7 +129,7 @@ async fn main() -> Result<()> {
             Some(id) => id,
             None => db.create_session(&config.agent_name, &project_root).await?,
         };
-        let exit_code = app::run_headless(
+        let exit_code = headless::run_headless(
             project_root,
             config,
             db,

--- a/koda-core/src/agent.rs
+++ b/koda-core/src/agent.rs
@@ -1,0 +1,65 @@
+//! KodaAgent — shared, immutable agent configuration.
+//!
+//! Holds everything that's constant across turns within a session:
+//! config, tools, system prompt, MCP registry. Shareable via `Arc`
+//! for parallel sub-agents.
+
+use crate::config::KodaConfig;
+use crate::mcp::McpRegistry;
+use crate::providers::{self, LlmProvider, ToolDefinition};
+use crate::tools::ToolRegistry;
+use crate::{inference, memory};
+
+use anyhow::Result;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Shared agent configuration. Immutable after construction.
+///
+/// Create once, share via `Arc<KodaAgent>` across sessions and sub-agents.
+pub struct KodaAgent {
+    pub config: KodaConfig,
+    pub project_root: PathBuf,
+    pub tools: ToolRegistry,
+    pub tool_defs: Vec<ToolDefinition>,
+    pub system_prompt: String,
+    pub mcp_registry: Arc<RwLock<McpRegistry>>,
+}
+
+impl KodaAgent {
+    /// Build a new agent from config and project root.
+    ///
+    /// Initializes tools, MCP servers, system prompt, and tool definitions.
+    pub async fn new(config: KodaConfig, project_root: PathBuf) -> Result<Self> {
+        let mcp_registry = Arc::new(RwLock::new(McpRegistry::new()));
+        {
+            let mut mcp = mcp_registry.write().await;
+            mcp.start_from_config(&project_root).await;
+        }
+
+        let tools = ToolRegistry::new(project_root.clone()).with_mcp_registry(mcp_registry.clone());
+        let tool_defs = tools.get_definitions(&config.allowed_tools);
+
+        let semantic_memory = memory::load(&project_root)?;
+        let system_prompt = inference::build_system_prompt(
+            &config.system_prompt,
+            &semantic_memory,
+            &config.agents_dir,
+        );
+
+        Ok(Self {
+            config,
+            project_root,
+            tools,
+            tool_defs,
+            system_prompt,
+            mcp_registry,
+        })
+    }
+
+    /// Create an LLM provider from this agent's config.
+    pub fn create_provider(&self) -> Box<dyn LlmProvider> {
+        providers::create_provider(&self.config)
+    }
+}

--- a/koda-core/src/agent.rs
+++ b/koda-core/src/agent.rs
@@ -1,12 +1,16 @@
-//! KodaAgent — shared, immutable agent configuration.
+//! KodaAgent — shared, immutable agent resources.
 //!
 //! Holds everything that's constant across turns within a session:
-//! config, tools, system prompt, MCP registry. Shareable via `Arc`
+//! tools, system prompt, MCP registry, project root. Shareable via `Arc`
 //! for parallel sub-agents.
+//!
+//! Note: `KodaConfig` is NOT stored here because the REPL allows
+//! switching models and providers mid-session. Config lives on the
+//! caller side and is passed to `KodaSession` per-turn.
 
 use crate::config::KodaConfig;
 use crate::mcp::McpRegistry;
-use crate::providers::{self, LlmProvider, ToolDefinition};
+use crate::providers::ToolDefinition;
 use crate::tools::ToolRegistry;
 use crate::{inference, memory};
 
@@ -15,11 +19,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// Shared agent configuration. Immutable after construction.
+/// Shared agent resources. Immutable after construction.
 ///
 /// Create once, share via `Arc<KodaAgent>` across sessions and sub-agents.
 pub struct KodaAgent {
-    pub config: KodaConfig,
     pub project_root: PathBuf,
     pub tools: ToolRegistry,
     pub tool_defs: Vec<ToolDefinition>,
@@ -31,7 +34,7 @@ impl KodaAgent {
     /// Build a new agent from config and project root.
     ///
     /// Initializes tools, MCP servers, system prompt, and tool definitions.
-    pub async fn new(config: KodaConfig, project_root: PathBuf) -> Result<Self> {
+    pub async fn new(config: &KodaConfig, project_root: PathBuf) -> Result<Self> {
         let mcp_registry = Arc::new(RwLock::new(McpRegistry::new()));
         {
             let mut mcp = mcp_registry.write().await;
@@ -49,17 +52,11 @@ impl KodaAgent {
         );
 
         Ok(Self {
-            config,
             project_root,
             tools,
             tool_defs,
             system_prompt,
             mcp_registry,
         })
-    }
-
-    /// Create an LLM provider from this agent's config.
-    pub fn create_provider(&self) -> Box<dyn LlmProvider> {
-        providers::create_provider(&self.config)
     }
 }

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! See `DESIGN.md` in the repository root for the full architectural rationale.
 
+pub mod agent;
 pub mod approval;
 pub mod config;
 pub mod context;
@@ -19,5 +20,6 @@ pub mod memory;
 pub mod preview;
 pub mod providers;
 pub mod runtime_env;
+pub mod session;
 pub mod tools;
 pub mod version;

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -6,10 +6,11 @@
 
 use crate::agent::KodaAgent;
 use crate::approval::{ApprovalMode, Settings};
+use crate::config::KodaConfig;
 use crate::db::Database;
 use crate::engine::{EngineCommand, EngineSink};
 use crate::loop_guard;
-use crate::providers::{ImageData, LlmProvider};
+use crate::providers::{self, ImageData, LlmProvider};
 
 use anyhow::Result;
 use std::sync::Arc;
@@ -31,9 +32,15 @@ pub struct KodaSession {
 }
 
 impl KodaSession {
-    /// Create a new session from an agent and database.
-    pub fn new(id: String, agent: Arc<KodaAgent>, db: Database, mode: ApprovalMode) -> Self {
-        let provider = agent.create_provider();
+    /// Create a new session from an agent, config, and database.
+    pub fn new(
+        id: String,
+        agent: Arc<KodaAgent>,
+        db: Database,
+        config: &KodaConfig,
+        mode: ApprovalMode,
+    ) -> Self {
+        let provider = providers::create_provider(config);
         let settings = Settings::load();
         Self {
             id,
@@ -51,6 +58,7 @@ impl KodaSession {
     /// This wraps `inference::inference_loop()` with all the session state.
     pub async fn run_turn(
         &mut self,
+        config: &KodaConfig,
         pending_images: Option<Vec<ImageData>>,
         sink: &dyn EngineSink,
         cmd_rx: &mut mpsc::Receiver<EngineCommand>,
@@ -58,7 +66,7 @@ impl KodaSession {
     ) -> Result<()> {
         crate::inference::inference_loop(
             &self.agent.project_root,
-            &self.agent.config,
+            config,
             &self.db,
             &self.id,
             &self.agent.system_prompt,
@@ -74,5 +82,10 @@ impl KodaSession {
             loop_continue_prompt,
         )
         .await
+    }
+
+    /// Replace the provider (e.g., after switching models or providers).
+    pub fn update_provider(&mut self, config: &KodaConfig) {
+        self.provider = providers::create_provider(config);
     }
 }

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -1,0 +1,78 @@
+//! KodaSession — per-conversation state.
+//!
+//! Holds mutable, per-turn state: database handle, session ID,
+//! provider instance, approval settings, and cancellation token.
+//! Instantiable N times for parallel sub-agents or cowork mode.
+
+use crate::agent::KodaAgent;
+use crate::approval::{ApprovalMode, Settings};
+use crate::db::Database;
+use crate::engine::{EngineCommand, EngineSink};
+use crate::loop_guard;
+use crate::providers::{ImageData, LlmProvider};
+
+use anyhow::Result;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+/// A single conversation session with its own state.
+///
+/// Each session has its own provider, approval settings, and cancel token.
+/// Multiple sessions can share the same `Arc<KodaAgent>`.
+pub struct KodaSession {
+    pub id: String,
+    pub agent: Arc<KodaAgent>,
+    pub db: Database,
+    pub provider: Box<dyn LlmProvider>,
+    pub mode: ApprovalMode,
+    pub settings: Settings,
+    pub cancel: CancellationToken,
+}
+
+impl KodaSession {
+    /// Create a new session from an agent and database.
+    pub fn new(id: String, agent: Arc<KodaAgent>, db: Database, mode: ApprovalMode) -> Self {
+        let provider = agent.create_provider();
+        let settings = Settings::load();
+        Self {
+            id,
+            agent,
+            db,
+            provider,
+            mode,
+            settings,
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    /// Run one inference turn: prompt → streaming → tool execution → response.
+    ///
+    /// This wraps `inference::inference_loop()` with all the session state.
+    pub async fn run_turn(
+        &mut self,
+        pending_images: Option<Vec<ImageData>>,
+        sink: &dyn EngineSink,
+        cmd_rx: &mut mpsc::Receiver<EngineCommand>,
+        loop_continue_prompt: &dyn Fn(u32, &[String]) -> loop_guard::LoopContinuation,
+    ) -> Result<()> {
+        crate::inference::inference_loop(
+            &self.agent.project_root,
+            &self.agent.config,
+            &self.db,
+            &self.id,
+            &self.agent.system_prompt,
+            self.provider.as_ref(),
+            &self.agent.tools,
+            &self.agent.tool_defs,
+            pending_images,
+            self.mode,
+            &mut self.settings,
+            sink,
+            self.cancel.clone(),
+            cmd_rx,
+            loop_continue_prompt,
+        )
+        .await
+    }
+}


### PR DESCRIPTION
## Phase 3 of v0.2.0 migration (#50)

Extracts `KodaAgent` and `KodaSession` structs, replaces 15+ parameter threading, and splits the 1127-line `app.rs` into focused modules.

### What changed

**koda-core:**
- `KodaAgent` — shared, immutable agent resources (tools, system prompt, MCP registry). Shareable via `Arc` for parallel sub-agents.
- `KodaSession` — per-conversation state (db, provider, settings, cancel token). `run_turn()` wraps `inference_loop()` with all session state. Instantiable N times for cowork mode.

**koda-cli:**
- `app.rs` (602 lines): Interactive REPL loop, uses `KodaAgent` + `KodaSession`
- `headless.rs` (88 lines): Single-prompt mode, same structs, no duplicated setup
- `commands.rs` (486 lines): `/compact`, `/mcp`, `/provider`, `/trust` handlers

### Steps
- [x] 3.1: `KodaAgent` struct in `koda-core/src/agent.rs`
- [x] 3.2: `KodaSession` struct in `koda-core/src/session.rs`
- [x] 3.3: Migrate CLI to use `KodaAgent` + `KodaSession`
- [x] 3.4: Split `app.rs` → `app.rs` + `headless.rs` + `commands.rs`
- [x] 3.5: Validation — 292 tests pass, clippy clean, zero behavior change